### PR TITLE
공통 Audit필드 추가 및 H2 db 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+	runtimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/ldif/delivery/DeliveryApplication.java
+++ b/src/main/java/com/ldif/delivery/DeliveryApplication.java
@@ -2,7 +2,9 @@ package com.ldif.delivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DeliveryApplication {
 

--- a/src/main/java/com/ldif/delivery/global/infrastructure/entity/BaseEntity.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/entity/BaseEntity.java
@@ -1,0 +1,46 @@
+package com.ldif.delivery.global.infrastructure.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AutoCloseable.class)
+public class BaseEntity {
+
+    // 1. 생성 시간
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    // 2. 생성자
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    // 3. 수정 시간
+    @LastModifiedDate
+    @Column
+    private LocalDateTime updatedAt;
+
+    // 4. 수정자
+    @LastModifiedBy
+    @Column
+    private String updatedBy;
+
+    // 5. 삭제 시간 (Soft Delete용)
+    @Column
+    private LocalDateTime deletedAt;
+
+    // 6. 삭제자
+    @Column
+    private String deletedBy;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,20 @@
 spring.application.name=delivery
+
+
+# 1. H2 데이터베이스 연결 설정
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# 2. H2 콘솔 활성화 (브라우저에서 DB 확인용)
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# 3. JPA/Hibernate 설정
+# 서버를 켤 때마다 테이블을 새로 생성 (엔티티 수정이 잦은 개발 단계에 적합)
+spring.jpa.hibernate.ddl-auto=update
+# 실행되는 SQL 쿼리를 콘솔에 출력
+spring.jpa.show-sql=true
+# 출력되는 SQL을 보기 좋게 포맷팅
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
테이블에 공통 Audit 필드를 BaseEntity.java에 추가하였습니다.

필요한 Entity에서 extends BaseEntity로 상속받아 쓰시면 됩니다.


그리고 로컬 개발에서 사용할 H2 DB를 세팅하기 위해 build.gradle과  application.property를 수정하였습니다.

프로그램실행될때 로컬에서 자동으로 DB가 실행이되고 

http://localhost:8080/h2-console  에서 테이블을 확인할 수 있습니다.

이것은 메모리에 올라가는 db로, 프로그램이 종료되면 삭제됩니다.



장답 SA에서 환경별 Profile과 프로젝트 패키지 구조를 참고하여 만들었습니다.


https://www.notion.so/teamsparta/SA-3442dc3ef5148012a0ffd9071ebbfd67



