### PR TITLE
Feature/user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     // JWT
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
-    runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.12.5'
-    runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.5'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     // QueryDSL
     implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,13 @@ repositories {
 }
 
 dependencies {
+	// JWT
+	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 	runtimeOnly 'com.h2database:h2'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/ldif/delivery/auth/application/service/AuthServiceV1.java
+++ b/src/main/java/com/ldif/delivery/auth/application/service/AuthServiceV1.java
@@ -1,0 +1,50 @@
+package com.ldif.delivery.auth.application.service;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import com.ldif.delivery.user.domain.repository.UserRepository;
+import com.ldif.delivery.user.presentation.dto.request.ReqSignupDto;
+import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceV1 {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public ResUserDto signup(ReqSignupDto reqSignupDto) {
+        String username = reqSignupDto.getUsername();
+        String password = passwordEncoder.encode(reqSignupDto.getPassword());
+        String nickname = reqSignupDto.getNickname();
+        UserRoleEnum role = reqSignupDto.getRole();
+
+        // 회원 중복 확인
+        Optional<UserEntity> checkUsername = userRepository.findByUsername(username);
+        if (checkUsername.isPresent()) {
+            throw new IllegalArgumentException("중복된 사용자가 존재합니다.");
+        }
+
+        // email 중복 확인
+        String email = reqSignupDto.getEmail();
+        Optional<UserEntity> checkEmail = userRepository.findByEmail(email);
+        if (checkEmail.isPresent()){
+            throw new IllegalArgumentException("중복된 Email 입니다.");
+        }
+
+        //TODO
+        //사용자 ROLE 확인? 확인필요
+
+        UserEntity user = new UserEntity(username, nickname, email, password, role);
+        UserEntity savedUser = userRepository.save(user);
+
+        return new ResUserDto(savedUser);
+    }
+}

--- a/src/main/java/com/ldif/delivery/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/ldif/delivery/auth/presentation/controller/AuthControllerV1.java
@@ -1,0 +1,53 @@
+package com.ldif.delivery.auth.presentation.controller;
+
+import com.ldif.delivery.auth.application.service.AuthServiceV1;
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
+import com.ldif.delivery.user.presentation.dto.request.ReqSignupDto;
+import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j(topic = "AuthController")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthControllerV1 {
+
+    private final AuthServiceV1 authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity <CommonResponse<ResUserDto>> signup(@Valid @RequestBody ReqSignupDto reqSignupDto, BindingResult bindingResult){
+
+        //Valiadation 예외처리
+        if(bindingResult.hasErrors()){
+            // BindingResult에 담긴 에러들을 우리 규격(FieldErrorDto)으로 변환
+            List<CommonResponse.FieldErrorDto> errors = bindingResult.getFieldErrors().stream()
+                    .map(error -> new CommonResponse.FieldErrorDto(error.getField(), error.getDefaultMessage()))
+                    .toList();
+
+            errors.forEach(err -> log.error("검증 실패 - 필드: {}, 메시지: {}", err.getField(), err.getMessage()));
+
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(CommonResponse.error(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR", errors));
+
+        }
+
+
+        ResUserDto resUserDto = authService.signup(reqSignupDto);
+
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "CREATED", resUserDto));
+
+    }
+}

--- a/src/main/java/com/ldif/delivery/auth/presentation/dto/ReqLoginDto.java
+++ b/src/main/java/com/ldif/delivery/auth/presentation/dto/ReqLoginDto.java
@@ -1,4 +1,4 @@
-package com.ldif.delivery.user.presentation.dto.request;
+package com.ldif.delivery.auth.presentation.dto;
 
 import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.constraints.Email;
@@ -7,18 +7,11 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
 @Setter
-public class ReqSignupDto {
+@Getter
+public class ReqLoginDto {
     @NotBlank
     private String username;
     @NotBlank
     private String password;
-    @NotBlank
-    private String nickname;
-    @Email
-    @NotBlank
-    private String email;
-    @NotNull
-    private UserRoleEnum role;
 }

--- a/src/main/java/com/ldif/delivery/auth/presentation/dto/ResLoginDto.java
+++ b/src/main/java/com/ldif/delivery/auth/presentation/dto/ResLoginDto.java
@@ -1,0 +1,21 @@
+package com.ldif.delivery.auth.presentation.dto;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ResLoginDto {
+    private String accessToken;
+    private String username;
+    private UserRoleEnum role;;
+
+    public ResLoginDto(String accessToken, String username, UserRoleEnum role){
+        this.accessToken = accessToken;
+        this.username = username;
+        this.role = role;
+    }
+
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ldif.delivery.auth.presentation.dto.ReqLoginDto;
+import com.ldif.delivery.auth.presentation.dto.ResLoginDto;
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider){
+        this.jwtTokenProvider = jwtTokenProvider;
+        setFilterProcessesUrl("/api/v1/auth/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        log.info("로그인 시도");
+        try{
+            ReqLoginDto reqLoginDto = new ObjectMapper().readValue(request.getInputStream(), ReqLoginDto.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            reqLoginDto.getUsername(),
+                            reqLoginDto.getPassword(),
+                            null
+                    )
+            );
+        }catch (IOException e){
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain,
+            Authentication authResult
+    ) throws IOException, ServletException {
+        log.info("로그인 성공 및 JWT 생성");
+        String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
+        UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
+
+        String token = jwtTokenProvider.createToken(username, role);
+
+        ResLoginDto resLoginDto = new ResLoginDto(token, username, role);
+
+        // 공통 응답 객체에 담기
+        CommonResponse<ResLoginDto> commonResponse = CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", resLoginDto);
+
+        // HTTP 응답 설정 (JSON 타입 및 인코딩)
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // ObjectMapper를 사용하여 JSON으로 변환 후 출력
+        String jsonResponse = new ObjectMapper().writeValueAsString(commonResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthenticationFilter.java
@@ -72,4 +72,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String jsonResponse = new ObjectMapper().writeValueAsString(commonResponse);
         response.getWriter().write(jsonResponse);
     }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) throws IOException, ServletException {
+        log.info("로그인 실패");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    }
 }

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthorizationFilter.java
@@ -1,0 +1,72 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+
+    public JwtAuthorizationFilter(JwtTokenProvider jwtTokenProvider, UserDetailsServiceImpl userDetailsService){
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected  void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtTokenProvider.getTokenFromHeader(req);
+
+        if (StringUtils.hasText(tokenValue)){
+            // JWT 토큰 substring
+            tokenValue = jwtTokenProvider.substringToken(tokenValue);
+
+            if (!jwtTokenProvider.validateToken(tokenValue)){
+                log.error("Token error");
+                return;
+            }
+
+            Claims info = jwtTokenProvider.getUserInfoFromToken(tokenValue);
+
+            try{
+                setAuthentiaction(info.getSubject());
+            }catch (Exception e){
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    // 인증 처리
+    public void setAuthentiaction(String username){
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    // 인증 객체 생성
+    private Authentication createAuthentication(String username){
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtTokenProvider.java
@@ -1,0 +1,55 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "Jwt log")
+@Component
+public class JwtTokenProvider {
+    // Header KEY 값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    // 사용자 권한 값의 KEY
+    public static final String AUTHORIZATION_KEY = "auth";
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+    // 토큰 만료시간
+    private final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    // create JWT Token
+    public String createToken(String username, UserRoleEnum role){
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(username)
+                        .claim(AUTHORIZATION_KEY, role)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+
+
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtTokenProvider.java
@@ -1,13 +1,15 @@
 package com.ldif.delivery.global.infrastructure.config.security;
 
 import com.ldif.delivery.user.domain.entity.UserRoleEnum;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.security.Key;
 import java.util.Base64;
@@ -50,6 +52,40 @@ public class JwtTokenProvider {
                         .compact();
     }
 
+    public String substringToken(String tokenValue){
+        if(StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)){
+            return tokenValue.substring(7);
+        }
+        throw new NullPointerException("Not Found Token");
+    }
+
+    public boolean validateToken(String token){
+        try{
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e){
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+
+        return false;
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    public String getTokenFromHeader(HttpServletRequest req) {
+
+        String bearerToken = req.getHeader(AUTHORIZATION_HEADER);
+
+        return StringUtils.hasText(bearerToken) ? bearerToken : null;
+    }
 
 
 }

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/PasswordConfig.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/SecurityConfig.java
@@ -1,0 +1,70 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsServiceImpl userDetailsService;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider, UserDetailsServiceImpl userDetailsService, AuthenticationConfiguration authenticationConfiguration){
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+        this.authenticationConfiguration = authenticationConfiguration;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+        filter.setAuthenticationManager(authenticationConfiguration.getAuthenticationManager());
+        return filter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정 (H2 콘솔 사용을 위해 비활성화)
+        http.csrf(AbstractHttpConfigurer::disable);
+        // H2 콘솔의 iframe 허용
+        http.headers(headers -> headers
+                .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+        );
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests(auth -> auth
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll()
+                .anyRequest().authenticated()
+        );
+
+        //필터 관리
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/SecurityConfig.java
@@ -34,10 +34,16 @@ public class SecurityConfig {
         return configuration.getAuthenticationManager();
     }
 
+    @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
         filter.setAuthenticationManager(authenticationConfiguration.getAuthenticationManager());
         return filter;
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtTokenProvider, userDetailsService);
     }
 
     @Bean
@@ -62,6 +68,7 @@ public class SecurityConfig {
         );
 
         //필터 관리
+        http.addFilterBefore(jwtAuthorizationFilter(), JwtAuthenticationFilter.class);
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/UserDetailsImpl.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/UserDetailsImpl.java
@@ -1,0 +1,58 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class UserDetailsImpl implements UserDetails {
+
+    private final UserEntity user;
+
+    public UserDetailsImpl(UserEntity user) { this.user = user; }
+
+    public UserEntity getUser() { return user; }
+
+    @Override
+    public String getPassword() { return user.getPassword(); }
+
+    @Override
+    public String getUsername() { return user.getUsername(); }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        UserRoleEnum role = user.getRole();
+        String authority = role.getAuthority();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/UserDetailsImpl.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/UserDetailsImpl.java
@@ -35,6 +35,20 @@ public class UserDetailsImpl implements UserDetails {
         return authorities;
     }
 
+    public boolean isMasterOrManger() {
+        return getAuthorities().stream()
+                .anyMatch(
+                        a -> a.getAuthority().equals("ROLE_MASTER") || a.getAuthority().equals("ROLE_MANAGER"));
+    }
+
+    public boolean hasPermission(String requestUsername){
+        if(isMasterOrManger()) return true;
+        return this.getUsername().equals(requestUsername);
+    }
+
+
+
+
     @Override
     public boolean isAccountNonExpired() {
         return true;

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/UserDetailsServiceImpl.java
@@ -1,0 +1,24 @@
+package com.ldif.delivery.global.infrastructure.config.security;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public UserDetailsServiceImpl(UserRepository userRepository) { this.userRepository = userRepository; }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserEntity user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Not Found " + username));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/entity/BaseEntity.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/entity/BaseEntity.java
@@ -8,12 +8,13 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(AutoCloseable.class)
+@EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
     // 1. 생성 시간

--- a/src/main/java/com/ldif/delivery/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,6 +26,12 @@ public class GlobalExceptionHandler {
         log.error("IllegalArgumentException 발생: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<CommonResponse<?>> handleAccessDeniedException(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(CommonResponse.error(HttpStatus.FORBIDDEN.value(), e.getMessage(), null));
     }
 
     /**

--- a/src/main/java/com/ldif/delivery/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package com.ldif.delivery.global.infrastructure.presentation.advice;
+
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * IllegalArgumentException 처리 (잘못된 인자 전달 시)
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponse<?>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("IllegalArgumentException 발생: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(HttpStatus.BAD_REQUEST.value(), e.getMessage(), null));
+    }
+
+    /**
+     * NullPointerException 처리 (참조 값이 null인 경우)
+     */
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<CommonResponse<?>> handleNullPointerException(NullPointerException e) {
+        log.error("NullPointerException 발생: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(CommonResponse.error(HttpStatus.NOT_FOUND.value(), e.getMessage() != null ? e.getMessage() : "Null pointer exception occurred", null));
+    }
+
+    /**
+     * DTO 검증 실패 시 (@Valid) 발생하는 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException 발생: {}", e.getMessage());
+
+        List<CommonResponse.FieldErrorDto> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> new CommonResponse.FieldErrorDto(error.getField(), error.getDefaultMessage()))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR", errors));
+    }
+
+    /**
+     * 엔티티 검증 실패 시 (DB 저장 직전 등) 발생하는 예외 처리
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CommonResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
+        log.error("ConstraintViolationException 발생: {}", e.getMessage());
+
+        List<CommonResponse.FieldErrorDto> errors = e.getConstraintViolations().stream()
+                .map(violation -> new CommonResponse.FieldErrorDto(
+                        violation.getPropertyPath().toString(),
+                        violation.getMessage()))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(HttpStatus.BAD_REQUEST.value(), "ENTITY_VALIDATION_ERROR", errors));
+    }
+
+    /**
+     * JPA 트랜잭션 커밋 시 발생하는 예외 처리 (내부에 ConstraintViolationException이 포함된 경우가 많음)
+     */
+    @ExceptionHandler(TransactionSystemException.class)
+    public ResponseEntity<CommonResponse<?>> handleTransactionSystemException(TransactionSystemException e) {
+        Throwable cause = e.getRootCause();
+        if (cause instanceof ConstraintViolationException) {
+            return handleConstraintViolationException((ConstraintViolationException) cause);
+        }
+        
+        log.error("TransactionSystemException 발생: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "TRANSACTION_ERROR", null));
+    }
+
+    /**
+     * 그 외 예상치 못한 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<?>> handleException(Exception e) {
+        log.error("예상치 못한 Exception 발생: ", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "INTERNAL_SERVER_ERROR", null));
+    }
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/presentation/advice/GlobalExceptionHandler.java
@@ -30,8 +30,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<CommonResponse<?>> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("AccessDeniedException 발생: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                .body(CommonResponse.error(HttpStatus.FORBIDDEN.value(), e.getMessage(), null));
+                .body(CommonResponse.error(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다.", null));
     }
 
     /**

--- a/src/main/java/com/ldif/delivery/global/infrastructure/presentation/dto/CommonResponse.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/presentation/dto/CommonResponse.java
@@ -1,0 +1,38 @@
+package com.ldif.delivery.global.infrastructure.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommonResponse<T> {
+    private int status;
+    private String message;
+    private T data;
+    private List<FieldErrorDto> errors; // 에러 상세 정보
+
+    // 성공 응답 (데이터 포함)
+    public static <T> CommonResponse<T> success(int status, String message, T data) {
+        return new CommonResponse<>(status, message, data, null);
+    }
+
+    // 에러 응답
+    public static CommonResponse<Void> error(int status, String message, List<FieldErrorDto> errors) {
+        return new CommonResponse<>(status, message, null, errors);
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class FieldErrorDto {
+        private String field;
+        private String message;
+    }
+
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/presentation/dto/CommonResponse.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/presentation/dto/CommonResponse.java
@@ -24,7 +24,7 @@ public class CommonResponse<T> {
     }
 
     // 에러 응답
-    public static CommonResponse<Void> error(int status, String message, List<FieldErrorDto> errors) {
+    public static <T> CommonResponse<T> error(int status, String message, List<FieldErrorDto> errors) {
         return new CommonResponse<>(status, message, null, errors);
     }
 

--- a/src/main/java/com/ldif/delivery/global/infrastructure/presentation/dto/PageResponseDto.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/presentation/dto/PageResponseDto.java
@@ -1,0 +1,30 @@
+package com.ldif.delivery.global.infrastructure.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@JsonPropertyOrder({ "content", "page", "size", "totalElements", "totalPages", "sort" })
+public class PageResponseDto<T> {
+    private final List<T> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final String sort;
+
+    public PageResponseDto(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.sort = page.getSort().stream()
+                .map(order -> order.getProperty() + "," + order.getDirection())
+                .collect(Collectors.joining("; "));
+    }
+}

--- a/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
@@ -19,7 +19,7 @@ public class UserServiceV1 {
 
         List<UserEntity> allUsers = userRepository.findAll();
 
-        List<ResUserDto> userDtoList = allUsers.stream()
+        return allUsers.stream()
                 .map(ResUserDto::new)
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
@@ -1,0 +1,28 @@
+package com.ldif.delivery.user.application.service;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.repository.UserRepository;
+import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceV1 {
+
+    private final UserRepository userRepository;
+
+    public List<ResUserDto> getUsers() {
+
+        List<UserEntity> allUsers = userRepository.findAll();
+
+        List<ResUserDto> userDtoList = allUsers.stream()
+                .map(ResUserDto::new)
+                .collect(Collectors.toList());
+
+    }
+
+}

--- a/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -25,4 +26,12 @@ public class UserServiceV1 {
 
     }
 
+    public ResUserDto getUserInfo(String username) {
+        UserEntity user = userRepository.findByUsername(username).orElseThrow(
+                () -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. username: " + username)
+        );
+
+        return new ResUserDto(user);
+
+    }
 }

--- a/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
+++ b/src/main/java/com/ldif/delivery/user/application/service/UserServiceV1.java
@@ -4,6 +4,8 @@ import com.ldif.delivery.user.domain.entity.UserEntity;
 import com.ldif.delivery.user.domain.repository.UserRepository;
 import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,13 +17,11 @@ public class UserServiceV1 {
 
     private final UserRepository userRepository;
 
-    public List<ResUserDto> getUsers() {
+    public Page<ResUserDto> getUsers(Pageable pageable) {
 
-        List<UserEntity> allUsers = userRepository.findAll();
+        Page<UserEntity> userPage = userRepository.findAll(pageable);
 
-        return allUsers.stream()
-                .map(ResUserDto::new)
-                .collect(Collectors.toList());
+        return userPage.map(ResUserDto::new);
 
     }
 

--- a/src/main/java/com/ldif/delivery/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/ldif/delivery/user/domain/entity/UserEntity.java
@@ -39,6 +39,15 @@ public class UserEntity extends BaseEntity {
     private Boolean isPublic = true;
 
 
+    public  UserEntity(String username, String nickname, String email, String password, UserRoleEnum role){
+        this.username = username;
+        this.nickname = nickname;
+        this.email = email;
+        this.password = password;
+        this.role = role;
+    }
+
+
 
 
 }

--- a/src/main/java/com/ldif/delivery/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/ldif/delivery/user/domain/entity/UserEntity.java
@@ -1,0 +1,44 @@
+package com.ldif.delivery.user.domain.entity;
+
+import com.ldif.delivery.global.infrastructure.entity.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "p_user")
+public class UserEntity extends BaseEntity {
+    @Id
+    @Size(min = 4, max = 10)
+    @Pattern(regexp = "^[a-z0-9]+$", message = "소문자와 숫자만 입력 가능합니다.")
+    @Column(name = "username", length = 10)
+    private String username;
+
+    @Column(nullable = false, length = 10)
+    private String nickname;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    @Enumerated(value = EnumType.STRING)
+    private UserRoleEnum role;
+
+    @Column
+    private Boolean isPublic = true;
+
+
+
+
+}

--- a/src/main/java/com/ldif/delivery/user/domain/entity/UserRoleEnum.java
+++ b/src/main/java/com/ldif/delivery/user/domain/entity/UserRoleEnum.java
@@ -1,0 +1,26 @@
+package com.ldif.delivery.user.domain.entity;
+
+public enum UserRoleEnum {
+    CUSTOMER(Authority.CUSTOMER),
+    OWNER(Authority.OWNER),
+    MANAGER(Authority.MANAGER),
+    MASTER(Authority.MASTER);
+
+
+    private final String authority;
+
+    UserRoleEnum(String authority) {
+        this.authority = authority;
+    }
+
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public static class Authority {
+        public static final String CUSTOMER = "ROLE_CUSTOMER";
+        public static final String OWNER = "ROLE_OWNER";
+        public static final String MANAGER = "ROLE_MANAGER";
+        public static final String MASTER = "ROLE_MASTER";
+    }
+}

--- a/src/main/java/com/ldif/delivery/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/ldif/delivery/user/domain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.ldif.delivery.user.domain.repository;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<UserEntity, String> {
+
+    Optional<UserEntity> findByUsername(String username);
+    Optional<UserEntity> findByEmail(String email);
+
+}

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -1,5 +1,7 @@
 package com.ldif.delivery.user.presentation.controller;
 
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
+import com.ldif.delivery.global.infrastructure.presentation.dto.PageResponseDto;
 import com.ldif.delivery.user.application.service.UserServiceV1;
 import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,15 +28,21 @@ public class UserControllerV1 {
     // Pagenation size파라미터 10,30,50만 허용 (그 외 기본 10건)
 
     @GetMapping
-    public ResponseEntity<Page<ResUserDto>> getUsers (
+    public ResponseEntity<CommonResponse<PageResponseDto<ResUserDto>>> getUsers (
             @PageableDefault(
                     size = 10,
                     sort = "createdAt",
                     direction = Sort.Direction.DESC
             ) Pageable pageable
     ) {
-        return ResponseEntity.ok(userService.getUsers(pageable));
+
+        Page<ResUserDto> userPage = userService.getUsers(pageable);
+
+        PageResponseDto<ResUserDto> data = new PageResponseDto<>(userPage);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS",data ));
+
+        //return ResponseEntity.ok(userService.getUsers(pageable));
     }
-
-
 }

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -41,8 +41,6 @@ public class UserControllerV1 {
         PageResponseDto<ResUserDto> data = new PageResponseDto<>(userPage);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS",data ));
-
-        //return ResponseEntity.ok(userService.getUsers(pageable));
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS",data));
     }
 }

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -1,8 +1,10 @@
 package com.ldif.delivery.user.presentation.controller;
 
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
 import com.ldif.delivery.global.infrastructure.presentation.dto.PageResponseDto;
 import com.ldif.delivery.user.application.service.UserServiceV1;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -11,6 +13,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,6 +31,7 @@ public class UserControllerV1 {
     // Pagenation size파라미터 10,30,50만 허용 (그 외 기본 10건)
 
     @GetMapping
+    @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER})
     public ResponseEntity<CommonResponse<PageResponseDto<ResUserDto>>> getUsers (
             @PageableDefault(
                     size = 10,
@@ -43,7 +49,14 @@ public class UserControllerV1 {
     }
 
     @GetMapping("/{username}")
-    public ResponseEntity<CommonResponse<ResUserDto>> getUserInfo (@PathVariable String username){
+    @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER, UserRoleEnum.Authority.CUSTOMER})
+    public ResponseEntity<CommonResponse<ResUserDto>> getUserInfo (@PathVariable String username, @AuthenticationPrincipal UserDetailsImpl loginUser){
+
+        if(!loginUser.hasPermission(username)){
+            throw new AccessDeniedException("접근 권한이 없습니다.");
+        }
+
+
         ResUserDto user = userService.getUserInfo(username);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -21,6 +21,9 @@ public class UserControllerV1 {
 
     private final UserServiceV1 userService;
 
+    //TODO
+    // Pagenation size파라미터 10,30,50만 허용 (그 외 기본 10건)
+
     @GetMapping
     public ResponseEntity<Page<ResUserDto>> getUsers (
             @PageableDefault(

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -11,9 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -42,5 +40,14 @@ public class UserControllerV1 {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS",data));
+    }
+
+    @GetMapping("/{username}")
+    public ResponseEntity<CommonResponse<ResUserDto>> getUserInfo (@PathVariable String username){
+        ResUserDto user = userService.getUserInfo(username);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", user));
+
     }
 }

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -1,0 +1,25 @@
+package com.ldif.delivery.user.presentation.controller;
+
+import com.ldif.delivery.user.application.service.UserServiceV1;
+import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserControllerV1 {
+
+    private final UserServiceV1 userService;
+
+    @GetMapping("/")
+    public List<ResUserDto> getUsers () {
+        return userService.getUsers();
+    }
+
+
+}

--- a/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/controller/UserControllerV1.java
@@ -3,6 +3,11 @@ package com.ldif.delivery.user.presentation.controller;
 import com.ldif.delivery.user.application.service.UserServiceV1;
 import com.ldif.delivery.user.presentation.dto.response.ResUserDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,9 +21,15 @@ public class UserControllerV1 {
 
     private final UserServiceV1 userService;
 
-    @GetMapping("/")
-    public List<ResUserDto> getUsers () {
-        return userService.getUsers();
+    @GetMapping
+    public ResponseEntity<Page<ResUserDto>> getUsers (
+            @PageableDefault(
+                    size = 10,
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+        return ResponseEntity.ok(userService.getUsers(pageable));
     }
 
 

--- a/src/main/java/com/ldif/delivery/user/presentation/dto/request/ReqSignupDto.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/dto/request/ReqSignupDto.java
@@ -1,0 +1,4 @@
+package com.ldif.delivery.user.presentation.dto.request;
+
+public class ReqSignupDto {
+}

--- a/src/main/java/com/ldif/delivery/user/presentation/dto/response/ResUserDto.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/dto/response/ResUserDto.java
@@ -12,13 +12,13 @@ public class ResUserDto {
     String nickname;
     String email;
     UserRoleEnum role;
-    Boolean isPublic;
+    String createdAt;
 
     public ResUserDto(UserEntity user) {
         this.username = user.getUsername();
         this.nickname = user.getNickname();
         this.email = user.getEmail();
         this.role = user.getRole();
-        this.isPublic = user.getIsPublic();
+        this.createdAt = user.getCreatedAt().toString();
     }
 }

--- a/src/main/java/com/ldif/delivery/user/presentation/dto/response/ResUserDto.java
+++ b/src/main/java/com/ldif/delivery/user/presentation/dto/response/ResUserDto.java
@@ -1,0 +1,24 @@
+package com.ldif.delivery.user.presentation.dto.response;
+
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResUserDto {
+    String username;
+    String nickname;
+    String email;
+    UserRoleEnum role;
+    Boolean isPublic;
+
+    public ResUserDto(UserEntity user) {
+        this.username = user.getUsername();
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+        this.role = user.getRole();
+        this.isPublic = user.getIsPublic();
+    }
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,28 @@
+
+
+# 1. H2 데이터베이스 연결 설정
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# 2. H2 콘솔 활성화 (브라우저에서 DB 확인용)
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# 실행되는 SQL 쿼리를 콘솔에 출력
+spring.jpa.show-sql=true
+# 출력되는 SQL을 보기 좋게 포맷팅
+spring.jpa.properties.hibernate.format_sql=true
+
+# SQL 스크립트 실행 시점을 Hibernate 초기화 이후로 늦춤 (가장 중요!)
+spring.jpa.defer-datasource-initialization=true
+
+# JWT Secret Key (예시 문자열입니다. 실제로는 더 복잡하게 만드세요)
+jwt.secret.key=${JWT_SECRET_KEY:}
+
+
+
+#ai api key
+spring.ai.google.genai.api-key=${GEMINI_API_KEY}
+spring.ai.google.genai.chat.options.model=gemini-2.5-flash

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,35 @@
+spring.application.name=delivery
+
+# 1. PostgreSQL 데이터베이스 연결 설정(환경 변수 권장)
+spring.datasource.url=jdbc:postgresql://localhost:5432/delivery_db
+spring.datasource.username=${POSTGRES_USER:postgres}
+spring.datasource.password=${POSTGRES_PASSWORD:}
+
+# 2. JPA/Hibernate 설정
+# 서버를 켤 때마다 테이블을 새로 생성 (엔티티 수정이 잦은 개발 단계에 적합)
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+#spring.jpa.hibernate.ddl-auto=create
+
+## 1. H2 데이터베이스 연결 설정
+#spring.datasource.url=jdbc:h2:mem:testdb
+#spring.datasource.driver-class-name=org.h2.Driver
+#spring.datasource.username=sa
+#spring.datasource.password=
+#
+## 2. H2 콘솔 활성화 (브라우저에서 DB 확인용)
+#spring.h2.console.enabled=true
+#spring.h2.console.path=/h2-console
+
+# 실행되는 SQL 쿼리를 콘솔에 출력
+spring.jpa.show-sql=true
+# 출력되는 SQL을 보기 좋게 포맷팅
+spring.jpa.properties.hibernate.format_sql=true
+
+# JWT Secret Key (예시 문자열입니다. 실제로는 더 복잡하게 만드세요)
+jwt.secret.key=${JWT_SECRET_KEY:}
+
+#ai api key
+spring.ai.google.genai.api-key=${GEMINI_API_KEY}
+spring.ai.google.genai.chat.options.model=gemini-2.5-flash
+

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -9,17 +9,6 @@ spring.datasource.password=${POSTGRES_PASSWORD:}
 # 서버를 켤 때마다 테이블을 새로 생성 (엔티티 수정이 잦은 개발 단계에 적합)
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-#spring.jpa.hibernate.ddl-auto=create
-
-## 1. H2 데이터베이스 연결 설정
-#spring.datasource.url=jdbc:h2:mem:testdb
-#spring.datasource.driver-class-name=org.h2.Driver
-#spring.datasource.username=sa
-#spring.datasource.password=
-#
-## 2. H2 콘솔 활성화 (브라우저에서 DB 확인용)
-#spring.h2.console.enabled=true
-#spring.h2.console.path=/h2-console
 
 # 실행되는 SQL 쿼리를 콘솔에 출력
 spring.jpa.show-sql=true

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,35 @@
+spring.application.name=delivery
+
+# 1. PostgreSQL 데이터베이스 연결 설정(환경 변수 권장)
+spring.datasource.url=jdbc:postgresql://localhost:5432/delivery_db
+spring.datasource.username=${POSTGRES_USER:postgres}
+spring.datasource.password=${POSTGRES_PASSWORD:}
+
+# 2. JPA/Hibernate 설정
+# 서버를 켤 때마다 테이블을 새로 생성 (엔티티 수정이 잦은 개발 단계에 적합)
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+#spring.jpa.hibernate.ddl-auto=create
+
+## 1. H2 데이터베이스 연결 설정
+#spring.datasource.url=jdbc:h2:mem:testdb
+#spring.datasource.driver-class-name=org.h2.Driver
+#spring.datasource.username=sa
+#spring.datasource.password=
+#
+## 2. H2 콘솔 활성화 (브라우저에서 DB 확인용)
+#spring.h2.console.enabled=true
+#spring.h2.console.path=/h2-console
+
+# 실행되는 SQL 쿼리를 콘솔에 출력
+spring.jpa.show-sql=true
+# 출력되는 SQL을 보기 좋게 포맷팅
+spring.jpa.properties.hibernate.format_sql=true
+
+# JWT Secret Key (예시 문자열입니다. 실제로는 더 복잡하게 만드세요)
+jwt.secret.key=${JWT_SECRET_KEY:}
+
+#ai api key
+spring.ai.google.genai.api-key=${GEMINI_API_KEY}
+spring.ai.google.genai.chat.options.model=gemini-2.5-flash
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,35 +1,7 @@
 spring.application.name=delivery
 
-# 1. PostgreSQL 데이터베이스 연결 설정(환경 변수 권장)
-spring.datasource.url=jdbc:postgresql://localhost:5432/delivery_db
-spring.datasource.username=${POSTGRES_USER:postgres}
-spring.datasource.password=${POSTGRES_PASSWORD:}
+#어떤 환경 실행할지 지정
+spring.profiles.active=local
 
-# 2. JPA/Hibernate 설정
-# 서버를 켤 때마다 테이블을 새로 생성 (엔티티 수정이 잦은 개발 단계에 적합)
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-#spring.jpa.hibernate.ddl-auto=create
 
-## 1. H2 데이터베이스 연결 설정
-#spring.datasource.url=jdbc:h2:mem:testdb
-#spring.datasource.driver-class-name=org.h2.Driver
-#spring.datasource.username=sa
-#spring.datasource.password=
-#
-## 2. H2 콘솔 활성화 (브라우저에서 DB 확인용)
-#spring.h2.console.enabled=true
-#spring.h2.console.path=/h2-console
-
-# 실행되는 SQL 쿼리를 콘솔에 출력
-spring.jpa.show-sql=true
-# 출력되는 SQL을 보기 좋게 포맷팅
-spring.jpa.properties.hibernate.format_sql=true
-
-# JWT Secret Key (예시 문자열입니다. 실제로는 더 복잡하게 만드세요)
-jwt.secret=${JWT_SECRET_KEY:}
-
-#ai api key
-spring.ai.google.genai.api-key=${GEMINI_API_KEY}
-spring.ai.google.genai.chat.options.model=gemini-2.5-flash
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,19 @@
+-- 1. 마스터 유저 (dongoan)
+INSERT INTO p_user (username, nickname, email, password, role, is_public, created_at, created_by)
+VALUES ('dongoan', '똔마스터', 'master@ldif.com', '$2a$10$zPKFwB3/qF3lqvxaY3mW1eqXk2B8v9waw452y/xh2EXEGr5lokCSG', 'MASTER', true, NOW(), 'system');
+
+-- 2. 매니저 유저 (manager01)
+INSERT INTO p_user (username, nickname, email, password, role, is_public, created_at, created_by)
+VALUES ('manager01', '운영요원', 'manager@ldif.com', '$2a$10$zPKFwB3/qF3lqvxaY3mW1eqXk2B8v9waw452y/xh2EXEGr5lokCSG', 'MANAGER', true, NOW(), 'system');
+
+-- 3. 사장님 유저 (owner01, owner02)
+INSERT INTO p_user (username, nickname, email, password, role, is_public, created_at, created_by)
+VALUES ('owner01', '치킨집사장', 'owner01@ldif.com', '$2a$10$zPKFwB3/qF3lqvxaY3mW1eqXk2B8v9waw452y/xh2EXEGr5lokCSG', 'OWNER', true, NOW(), 'system');
+INSERT INTO p_user (username, nickname, email, password, role, is_public, created_at, created_by)
+VALUES ('owner02', '피자집사장', 'owner02@ldif.com', '$2a$10$zPKFwB3/qF3lqvxaY3mW1eqXk2B8v9waw452y/xh2EXEGr5lokCSG', 'OWNER', true, NOW(), 'system');
+
+-- 4. 손님 유저 (customer01, customer02)
+INSERT INTO p_user (username, nickname, email, password, role, is_public, created_at, created_by)
+VALUES ('customer01', '배달이좋아', 'customer01@ldif.com', '$2a$10$zPKFwB3/qF3lqvxaY3mW1eqXk2B8v9waw452y/xh2EXEGr5lokCSG', 'CUSTOMER', true, NOW(), 'system');
+INSERT INTO p_user (username, nickname, email, password, role, is_public, created_at, created_by)
+VALUES ('customer02', '오늘도배달', 'customer02@ldif.com', '$2a$10$zPKFwB3/qF3lqvxaY3mW1eqXk2B8v9waw452y/xh2EXEGr5lokCSG', 'CUSTOMER', true, NOW(), 'system');


### PR DESCRIPTION
user, 권한기능 까지 넣으려다보니 한번에 풀리퀘스트하는 양이 너무 많아져버렸네요 ㅠ
다음엔 더 잘게 나눠서 하겠습니다.

변경사항
1. JWT 토큰 생성 및 인증 구현
2. /auth/login, /auth/signup 구현
3. GET /users  GET  /users/{username} 구현    (PUT DELETE 미구현)
4. api에서 권한에 따라 접근 거부 구현
5. commonResponse 구현
6. auth관련 필터 구현

SA문서에 3.API명세서 를 보시면
공통 Response 형식이 있습니다.
이것을 구현하기위해 commonResponse를 만들었습니다.

사용법은 UserControllerV1을 참고해주세요. 



**중요한 점**

auth/login을 통해 로그인을 시도하면 서버에서
accessToken을 줍니다.


api에 
@Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER, UserRoleEnum.Authority.CUSTOMER})
이런식으로 권한을 부여할 수 있는데

api 호출할 때 토큰을 넣어줘야 권한을 검증할 수 있습니다.
Postman으로 테스트시 Authorization에 토큰을 넣어주면 됩니다.



자세한건 
코드에 코멘트를 달아놓겠습니다.
참고해주세요 



