### PR TITLE
Refactor/메뉴 관련 권한 추가, 응답 통일

### DIFF
--- a/src/main/java/com/ldif/delivery/ai/application/service/AiServiceV1.java
+++ b/src/main/java/com/ldif/delivery/ai/application/service/AiServiceV1.java
@@ -6,8 +6,10 @@ import com.ldif.delivery.ai.infrastructure.api.gemini.client.GeminiClient;
 import com.ldif.delivery.ai.infrastructure.api.gemini.dto.response.GeminiResponseDto;
 import com.ldif.delivery.ai.presentation.dto.AiRequest;
 import com.ldif.delivery.ai.presentation.dto.AiResponse;
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
@@ -22,9 +24,9 @@ public class AiServiceV1 {
     private final GeminiClient geminiClient;
 
     @Transactional
-    public AiResponse setDescription(@Valid AiRequest aiRequest) {
+    public AiResponse setDescription(@Valid AiRequest aiRequest, @AuthenticationPrincipal UserDetailsImpl loginUser) {
         GeminiResponseDto result = geminiClient.call(aiRequest.getPrompt());
-        AiRequestLogEntity aiRequestLogEntity = new AiRequestLogEntity(aiRequest);
+        AiRequestLogEntity aiRequestLogEntity = new AiRequestLogEntity(aiRequest, loginUser);
         aiRequestLogEntity.setAiResponse(result);
         aiRequestLogRepository.save(aiRequestLogEntity);
         return new AiResponse(aiRequestLogEntity);

--- a/src/main/java/com/ldif/delivery/ai/domain/entity/AiRequestLogEntity.java
+++ b/src/main/java/com/ldif/delivery/ai/domain/entity/AiRequestLogEntity.java
@@ -2,6 +2,8 @@ package com.ldif.delivery.ai.domain.entity;
 
 import com.ldif.delivery.ai.infrastructure.api.gemini.dto.response.GeminiResponseDto;
 import com.ldif.delivery.ai.presentation.dto.AiRequest;
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
+import com.ldif.delivery.user.domain.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -45,12 +47,13 @@ public class AiRequestLogEntity {
     private String createdBy;
 
     //요청자
-//    @ManyToOne
-//    @JoinColumn(name = userId, nullable = false)
-//    private User user;
+    @ManyToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "username", nullable = false)
+    private UserEntity userEntity;
 
-    public AiRequestLogEntity(AiRequest aiRequest) {
+    public AiRequestLogEntity(AiRequest aiRequest, UserDetailsImpl loginUser) {
         this.requestType = aiRequest.getPrompt();
+        this.userEntity = loginUser.getUser();
     }
 
     public void setAiResponse(GeminiResponseDto geminiResponseDto) {

--- a/src/main/java/com/ldif/delivery/ai/presentation/controller/AiControllerV1.java
+++ b/src/main/java/com/ldif/delivery/ai/presentation/controller/AiControllerV1.java
@@ -4,9 +4,11 @@ import com.ldif.delivery.ai.application.service.AiServiceV1;
 import com.ldif.delivery.ai.presentation.dto.AiRequest;
 import com.ldif.delivery.ai.presentation.dto.AiResponse;
 import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
 import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,8 +26,8 @@ public class AiControllerV1 {
 
     @PostMapping("/product-description")
     @Secured(UserRoleEnum.Authority.OWNER)
-    public ResponseEntity<AiResponse> setDescription(@Valid @RequestBody AiRequest aiRequest, @AuthenticationPrincipal UserDetailsImpl loginUser) {
-        return ResponseEntity.ok(aiServiceV1.setDescription(aiRequest, loginUser));
+    public ResponseEntity<CommonResponse<AiResponse>> setDescription(@Valid @RequestBody AiRequest aiRequest, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", aiServiceV1.setDescription(aiRequest, loginUser)));
     }
 
 }

--- a/src/main/java/com/ldif/delivery/ai/presentation/controller/AiControllerV1.java
+++ b/src/main/java/com/ldif/delivery/ai/presentation/controller/AiControllerV1.java
@@ -3,9 +3,13 @@ package com.ldif.delivery.ai.presentation.controller;
 import com.ldif.delivery.ai.application.service.AiServiceV1;
 import com.ldif.delivery.ai.presentation.dto.AiRequest;
 import com.ldif.delivery.ai.presentation.dto.AiResponse;
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +23,9 @@ public class AiControllerV1 {
     private final AiServiceV1 aiServiceV1;
 
     @PostMapping("/product-description")
-    public ResponseEntity<AiResponse> setDescription(@Valid @RequestBody AiRequest aiRequest) {
-        return ResponseEntity.ok(aiServiceV1.setDescription(aiRequest));
+    @Secured(UserRoleEnum.Authority.OWNER)
+    public ResponseEntity<AiResponse> setDescription(@Valid @RequestBody AiRequest aiRequest, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        return ResponseEntity.ok(aiServiceV1.setDescription(aiRequest, loginUser));
     }
 
 }

--- a/src/main/java/com/ldif/delivery/ai/presentation/controller/AiControllerV1.java
+++ b/src/main/java/com/ldif/delivery/ai/presentation/controller/AiControllerV1.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/ai")
+@RequestMapping("/api/v1/ai")
 @RequiredArgsConstructor
 public class AiControllerV1 {
 

--- a/src/main/java/com/ldif/delivery/menu/application/service/MenuServiceV1.java
+++ b/src/main/java/com/ldif/delivery/menu/application/service/MenuServiceV1.java
@@ -57,7 +57,7 @@ public class MenuServiceV1 {
 //        }
 //
 
-        menuEntity.delete();
+        menuEntity.delete(loginUser.getUsername());
     }
 
     //메뉴 숨김 처리

--- a/src/main/java/com/ldif/delivery/menu/application/service/MenuServiceV1.java
+++ b/src/main/java/com/ldif/delivery/menu/application/service/MenuServiceV1.java
@@ -3,6 +3,7 @@ package com.ldif.delivery.menu.application.service;
 import com.ldif.delivery.ai.application.service.AiServiceV1;
 import com.ldif.delivery.ai.presentation.dto.AiRequest;
 import com.ldif.delivery.ai.presentation.dto.AiResponse;
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import com.ldif.delivery.menu.domain.entity.MenuEntity;
 import com.ldif.delivery.menu.domain.repository.MenuRepository;
 import com.ldif.delivery.menu.presentation.dto.MenuRequest;
@@ -27,31 +28,76 @@ public class MenuServiceV1 {
     private final MenuRepository menuRepository;
     private final AiServiceV1 aiServiceV1;
 
+    //메뉴 상세 조회
     public MenuResponse getMenu(UUID id) {
         MenuEntity menuEntity = findMenuById(id);
         return new MenuResponse(menuEntity);
     }
 
+    //메뉴 수정
     @Transactional
-    public MenuResponse updateMenu(UUID id, @Valid MenuRequest request) {
+    public MenuResponse updateMenu(UUID id, @Valid MenuRequest request, UserDetailsImpl loginUser) {
         MenuEntity menuEntity = findMenuById(id);
+
+//        if(!loginUser.hasPermission(menuEntity.getStoreEntity().getOwnerId())){
+//            throw new AccessDeniedException("접근 권한이 없습니다.");
+//        }
+//
         menuEntity.update(request);
         return new MenuResponse(menuEntity);
     }
 
+    //메뉴 삭제(소프트)
     @Transactional
-    public void deleteMenu(UUID id) {
+    public void deleteMenu(UUID id, UserDetailsImpl loginUser) {
         MenuEntity menuEntity = findMenuById(id);
+
+//        if(!loginUser.hasPermission(menuEntity.getStoreEntity().getOwnerId())){
+//            throw new AccessDeniedException("접근 권한이 없습니다.");
+//        }
+//
+
         menuEntity.delete();
     }
 
+    //메뉴 숨김 처리
     @Transactional
-    public MenuResponse hideMenu(UUID id) {
+    public MenuResponse hideMenu(UUID id, UserDetailsImpl loginUser) {
         MenuEntity menuEntity = findMenuById(id);
+
+//        if(!loginUser.hasPermission(menuEntity.getStoreEntity().getOwnerId())){
+//            throw new AccessDeniedException("접근 권한이 없습니다.");
+//        }
+//
+
         menuEntity.hide();
         return new MenuResponse(menuEntity);
     }
 
+    //메뉴 등록(AI 설명 생성 옵션)
+    @Transactional
+    public MenuResponse setMenu(@Valid MenuRequest request, StoreEntity store, UserDetailsImpl loginUser) {
+        MenuEntity menuEntity = new MenuEntity(request, store);
+        if (Boolean.TRUE.equals(request.getAiDescription())) {
+            AiRequest aiRequest = new AiRequest();
+            aiRequest.setPrompt(request.getAiPrompt());
+            AiResponse aiResponse = aiServiceV1.setDescription(aiRequest, loginUser);
+            menuEntity.setDescription(aiResponse.getResult());
+        }
+        menuRepository.save(menuEntity);
+        return new MenuResponse(menuEntity);
+    }
+
+    //메뉴 목록 조회
+    public Page<MenuResponse> getMenus(Pageable pageable, String keyword, UUID storeId) {
+        Page<MenuEntity> menuList;
+
+        menuList = menuRepository.findAllByStoreEntity_StoreIdAndNameContainingIgnoreCaseAndIsDeletedFalse(storeId, keyword, pageable);
+
+        return menuList.map(MenuResponse::new);
+    }
+
+    //메뉴 조회
     private MenuEntity findMenuById(UUID id) {
         MenuEntity menuEntity = menuRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("메뉴 없음." + id));
         if (menuEntity.getIsDeleted()) {
@@ -60,24 +106,4 @@ public class MenuServiceV1 {
         return menuEntity;
     }
 
-    @Transactional
-    public MenuResponse setMenu(@Valid MenuRequest request, StoreEntity store) {
-        MenuEntity menuEntity = new MenuEntity(request, store);
-        if (Boolean.TRUE.equals(request.getAiDescription())) {
-            AiRequest aiRequest = new AiRequest();
-            aiRequest.setPrompt(request.getAiPrompt());
-            AiResponse aiResponse = aiServiceV1.setDescription(aiRequest);
-            menuEntity.setDescription(aiResponse.getResult());
-        }
-        menuRepository.save(menuEntity);
-        return new MenuResponse(menuEntity);
-    }
-
-    public Page<MenuResponse> getMenus(Pageable pageable, String keyword, UUID storeId) {
-        Page<MenuEntity> menuList;
-
-        menuList = menuRepository.findAllByStoreEntity_StoreIdAndNameContainingIgnoreCaseAndIsDeletedFalse(storeId, keyword, pageable);
-
-        return menuList.map(MenuResponse::new);
-    }
 }

--- a/src/main/java/com/ldif/delivery/menu/domain/entity/MenuEntity.java
+++ b/src/main/java/com/ldif/delivery/menu/domain/entity/MenuEntity.java
@@ -62,9 +62,9 @@ public class MenuEntity extends BaseEntity {
         isHidden = !isHidden;
     }
 
-    public void delete() {
+    public void delete(String username) {
         this.isDeleted = true;
-        super.softDelete("임시 이름");
+        super.softDelete(username);
     }
 
     public void setDescription(String description) {

--- a/src/main/java/com/ldif/delivery/menu/domain/entity/MenuEntity.java
+++ b/src/main/java/com/ldif/delivery/menu/domain/entity/MenuEntity.java
@@ -41,6 +41,10 @@ public class MenuEntity extends BaseEntity {
     @JoinColumn(name = "store_id", nullable = false)
     private StoreEntity storeEntity;
 
+    public UUID getStoreId() {
+        return storeEntity != null ? storeEntity.getStoreId() : null;
+    }
+
     public MenuEntity(MenuRequest request, StoreEntity storeEntity) {
         this.storeEntity = storeEntity;
         this.name = request.getName();

--- a/src/main/java/com/ldif/delivery/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/ldif/delivery/menu/presentation/controller/MenuControllerV1.java
@@ -1,12 +1,14 @@
 package com.ldif.delivery.menu.presentation.controller;
 
 import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
 import com.ldif.delivery.menu.application.service.MenuServiceV1;
 import com.ldif.delivery.menu.presentation.dto.MenuRequest;
 import com.ldif.delivery.menu.presentation.dto.MenuResponse;
 import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,26 +24,31 @@ public class MenuControllerV1 {
     private final MenuServiceV1 menuService;
 
     @GetMapping("/{id}")
-    public ResponseEntity<MenuResponse> getMenu(@PathVariable UUID id) {
-        return ResponseEntity.ok(menuService.getMenu(id));
+    public ResponseEntity<CommonResponse<MenuResponse>> getMenu(@PathVariable UUID id) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", menuService.getMenu(id)));
     }
 
     @PutMapping("/{id}")
     @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER, UserRoleEnum.Authority.OWNER})
-    public ResponseEntity<MenuResponse> updateMenu(@PathVariable UUID id, @Valid @RequestBody MenuRequest request, @AuthenticationPrincipal UserDetailsImpl loginUser) {
-        return ResponseEntity.ok(menuService.updateMenu(id, request, loginUser));
+    public ResponseEntity<CommonResponse<MenuResponse>> updateMenu(@PathVariable UUID id, @Valid @RequestBody MenuRequest request, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", menuService.updateMenu(id, request, loginUser)));
     }
 
     @DeleteMapping("/{id}")
     @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.OWNER})
-    public void deleteMenu(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+    public ResponseEntity<CommonResponse<String>> deleteMenu(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl loginUser) {
         menuService.deleteMenu(id, loginUser);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", "deleted"));
     }
 
     @PatchMapping("/{id}/hide")
     @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER, UserRoleEnum.Authority.OWNER})
-    public ResponseEntity<MenuResponse> hideMenu(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl loginUser) {
-        return ResponseEntity.ok(menuService.hideMenu(id, loginUser));
+    public ResponseEntity<CommonResponse<MenuResponse>> hideMenu(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", menuService.hideMenu(id, loginUser)));
     }
 
 }

--- a/src/main/java/com/ldif/delivery/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/ldif/delivery/menu/presentation/controller/MenuControllerV1.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/menus")
+@RequestMapping("/api/v1/menus")
 @RequiredArgsConstructor
 public class MenuControllerV1 {
 

--- a/src/main/java/com/ldif/delivery/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/ldif/delivery/menu/presentation/controller/MenuControllerV1.java
@@ -1,11 +1,15 @@
 package com.ldif.delivery.menu.presentation.controller;
 
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import com.ldif.delivery.menu.application.service.MenuServiceV1;
 import com.ldif.delivery.menu.presentation.dto.MenuRequest;
 import com.ldif.delivery.menu.presentation.dto.MenuResponse;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -23,19 +27,21 @@ public class MenuControllerV1 {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<MenuResponse> updateMenu(@PathVariable UUID id, @Valid @RequestBody MenuRequest request) {
-        return ResponseEntity.ok(menuService.updateMenu(id, request));
+    @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER, UserRoleEnum.Authority.OWNER})
+    public ResponseEntity<MenuResponse> updateMenu(@PathVariable UUID id, @Valid @RequestBody MenuRequest request, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        return ResponseEntity.ok(menuService.updateMenu(id, request, loginUser));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteMenu(@PathVariable UUID id) {
-        menuService.deleteMenu(id);
-        return ResponseEntity.noContent().build();
+    @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.OWNER})
+    public void deleteMenu(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        menuService.deleteMenu(id, loginUser);
     }
 
     @PatchMapping("/{id}/hide")
-    public ResponseEntity<MenuResponse> hideMenu(@PathVariable UUID id) {
-        return ResponseEntity.ok(menuService.hideMenu(id));
+    @Secured({UserRoleEnum.Authority.MASTER, UserRoleEnum.Authority.MANAGER, UserRoleEnum.Authority.OWNER})
+    public ResponseEntity<MenuResponse> hideMenu(@PathVariable UUID id, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+        return ResponseEntity.ok(menuService.hideMenu(id, loginUser));
     }
 
 }

--- a/src/main/java/com/ldif/delivery/store/application/service/StoreServiceV1.java
+++ b/src/main/java/com/ldif/delivery/store/application/service/StoreServiceV1.java
@@ -1,13 +1,14 @@
 package com.ldif.delivery.store.application.service;
 
 
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import com.ldif.delivery.menu.application.service.MenuServiceV1;
 import com.ldif.delivery.menu.presentation.dto.MenuRequest;
 import com.ldif.delivery.menu.presentation.dto.MenuResponse;
-import com.ldif.delivery.store.presentation.dto.StoreRequest;
-import com.ldif.delivery.store.presentation.dto.StoreResponse;
 import com.ldif.delivery.store.domain.entity.StoreEntity;
 import com.ldif.delivery.store.domain.repository.StoreRepository;
+import com.ldif.delivery.store.presentation.dto.StoreRequest;
+import com.ldif.delivery.store.presentation.dto.StoreResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -27,7 +28,7 @@ public class StoreServiceV1 {
     private final MenuServiceV1 menuServiceV1;
 
     @Transactional
-    public UUID createStore(StoreRequest request){
+    public UUID createStore(StoreRequest request) {
 
         StoreEntity store = new StoreEntity(
                 request.getName(),
@@ -38,7 +39,7 @@ public class StoreServiceV1 {
         return storeRepository.save(store).getStoreId();
     }
 
-    public StoreResponse getStore(UUID storeId){
+    public StoreResponse getStore(UUID storeId) {
 
         StoreEntity store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
@@ -51,7 +52,7 @@ public class StoreServiceV1 {
     }
 
     @Transactional
-    public void updateStore(UUID storeId, StoreRequest request){
+    public void updateStore(UUID storeId, StoreRequest request) {
 
         StoreEntity store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
@@ -68,7 +69,7 @@ public class StoreServiceV1 {
     }
 
     @Transactional
-    public void deleteStore(UUID storeId){
+    public void deleteStore(UUID storeId) {
 
         StoreEntity store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
@@ -79,11 +80,16 @@ public class StoreServiceV1 {
     }
 
     @Transactional
-    public MenuResponse newMenu(UUID storeId, MenuRequest request) {
+    public MenuResponse newMenu(UUID storeId, MenuRequest request, UserDetailsImpl loginUser) {
+
         StoreEntity store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new IllegalArgumentException("가게를 찾을 수 없습니다."));
 
-        return menuServiceV1.setMenu(request, store);
+//        if(!loginUser.hasPermission(store.getOwnerId())){
+//            throw new AccessDeniedException("접근 권한이 없습니다.");
+//        }
+
+        return menuServiceV1.setMenu(request, store, loginUser);
     }
 
     public Page<MenuResponse> getMenus(String keyword, int page, int size, String sort, UUID storeId) {

--- a/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
@@ -1,6 +1,8 @@
 package com.ldif.delivery.store.presentation.controller;
 
 import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
+import com.ldif.delivery.global.infrastructure.presentation.dto.CommonResponse;
+import com.ldif.delivery.global.infrastructure.presentation.dto.PageResponseDto;
 import com.ldif.delivery.menu.presentation.dto.MenuRequest;
 import com.ldif.delivery.menu.presentation.dto.MenuResponse;
 import com.ldif.delivery.store.application.service.StoreServiceV1;
@@ -10,6 +12,7 @@ import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -54,19 +57,24 @@ public class StoreControllerV1 {
 
     @PostMapping("/{storeId}/menus")
     @Secured(UserRoleEnum.Authority.OWNER)
-    public ResponseEntity<MenuResponse> setMenu(@PathVariable UUID storeId, @Valid @RequestBody MenuRequest request, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+    public ResponseEntity<CommonResponse<MenuResponse>> setMenu(@PathVariable UUID storeId, @Valid @RequestBody MenuRequest request, @AuthenticationPrincipal UserDetailsImpl loginUser) {
 
-        return ResponseEntity.ok(storeServiceV1.newMenu(storeId, request, loginUser));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", storeServiceV1.newMenu(storeId, request, loginUser)));
     }
 
     @GetMapping("/{storeId}/menus")
-    public Page<MenuResponse> getMenus(
+    public ResponseEntity<CommonResponse<PageResponseDto<MenuResponse>>> getMenus(
             @RequestParam("keyword") String keyword,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size,
             @RequestParam("sort") String sort,
             @PathVariable UUID storeId
     ) {
-        return storeServiceV1.getMenus(keyword, page, size, sort, storeId);
+        Page<MenuResponse> menuPage = storeServiceV1.getMenus(keyword, page, size, sort, storeId);
+        PageResponseDto<MenuResponse> data = new PageResponseDto<>(menuPage);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", data));
     }
 }

--- a/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
@@ -1,9 +1,14 @@
 package com.ldif.delivery.store.presentation.controller;
 
+import com.ldif.delivery.menu.presentation.dto.MenuRequest;
+import com.ldif.delivery.menu.presentation.dto.MenuResponse;
 import com.ldif.delivery.store.presentation.dto.StoreRequest;
 import com.ldif.delivery.store.presentation.dto.StoreResponse;
 import com.ldif.delivery.store.application.service.StoreServiceV1;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
@@ -40,5 +45,21 @@ public class StoreControllerV1 {
     @DeleteMapping("/{storeId}")
     public void deleteStore(@PathVariable UUID storeId) {
         storeServiceV1.deleteStore(storeId);
+    }
+
+    @PostMapping("/{storeId}/menus")
+    public ResponseEntity<MenuResponse> setMenu(@PathVariable UUID storeId, @Valid @RequestBody MenuRequest request) {
+        return ResponseEntity.ok(storeServiceV1.newMenu(storeId, request));
+    }
+
+    @GetMapping("/{storeId}/menus")
+    public Page<MenuResponse> getMenus(
+            @RequestParam("keyword") String keyword,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size,
+            @RequestParam("sort") String sort,
+            @PathVariable UUID storeId
+    ) {
+        return storeServiceV1.getMenus(keyword, page, size, sort, storeId);
     }
 }

--- a/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
@@ -1,15 +1,20 @@
 package com.ldif.delivery.store.presentation.controller;
 
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import com.ldif.delivery.menu.presentation.dto.MenuRequest;
 import com.ldif.delivery.menu.presentation.dto.MenuResponse;
+import com.ldif.delivery.store.application.service.StoreServiceV1;
 import com.ldif.delivery.store.presentation.dto.StoreRequest;
 import com.ldif.delivery.store.presentation.dto.StoreResponse;
-import com.ldif.delivery.store.application.service.StoreServiceV1;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.UUID;
 
 @RestController
@@ -20,7 +25,7 @@ public class StoreControllerV1 {
     private final StoreServiceV1 storeServiceV1;
 
     @PostMapping
-    public UUID createStore(@RequestBody StoreRequest request){
+    public UUID createStore(@RequestBody StoreRequest request) {
         return storeServiceV1.createStore(request);
     }
 // 인증/인가 적용 후 사용
@@ -32,13 +37,13 @@ public class StoreControllerV1 {
 //    }
 
     @GetMapping("/{storeId}")
-    public StoreResponse getStore(@PathVariable UUID storeId){
+    public StoreResponse getStore(@PathVariable UUID storeId) {
         return storeServiceV1.getStore(storeId);
     }
 
     @PutMapping("/{storeId}")
     public void updateStore(@PathVariable UUID storeId,
-                            @RequestBody StoreRequest request){
+                            @RequestBody StoreRequest request) {
         storeServiceV1.updateStore(storeId, request);
     }
 
@@ -48,8 +53,10 @@ public class StoreControllerV1 {
     }
 
     @PostMapping("/{storeId}/menus")
-    public ResponseEntity<MenuResponse> setMenu(@PathVariable UUID storeId, @Valid @RequestBody MenuRequest request) {
-        return ResponseEntity.ok(storeServiceV1.newMenu(storeId, request));
+    @Secured(UserRoleEnum.Authority.OWNER)
+    public ResponseEntity<MenuResponse> setMenu(@PathVariable UUID storeId, @Valid @RequestBody MenuRequest request, @AuthenticationPrincipal UserDetailsImpl loginUser) {
+
+        return ResponseEntity.ok(storeServiceV1.newMenu(storeId, request, loginUser));
     }
 
     @GetMapping("/{storeId}/menus")

--- a/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/ldif/delivery/store/presentation/controller/StoreControllerV1.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/stores")
+@RequestMapping("/api/v1/stores")
 public class StoreControllerV1 {
 
     private final StoreServiceV1 storeServiceV1;


### PR DESCRIPTION
### 변경 내용
- api 권한 부여
- CommonResponse 적용
- soft delete와 AiRequestLogEntity에 유저 정보 적용

### 참고사항
- MenuEntity에 편의를 위한 getStoreId 메서드 추가
- mapping url 제공된 baseURL 기준으로 수정

---
Close #25 