### PR TITLE
Security/매 요청마다 JWT와 DB 권한 비교 검증 로직 추가

### DIFF
--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/JwtAuthorizationFilter.java
@@ -6,8 +6,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -44,7 +46,31 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
             Claims info = jwtTokenProvider.getUserInfoFromToken(tokenValue);
 
             try{
+                // 1. JWT에서 role 추출
+                String tokenRole = (String) info.get("role");
+
+                // 2. DB에서 role 조회
+                UserDetails userDetails = userDetailsService.loadUserByUsername(info.getSubject());
+                String dbRole = userDetails.getAuthorities().stream()
+                        .findFirst()
+                        .map(GrantedAuthority::getAuthority)
+                        .orElseThrow(() -> new RuntimeException("권한 정보가 없습니다."));
+
+                // 3. 불일치 시 차단 대신 재로그인 유도
+                if (!tokenRole.equals(dbRole)) {
+                    log.warn("권한 불일치 - JWT: {}, DB: {}", tokenRole, dbRole, info.getSubject());
+                    res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    res.setContentType("application/json");
+                    res.setCharacterEncoding("UTF-8");
+                    res.getWriter().write(
+                            "{\"status\": 401, " +
+                                    "\"message\": \"권한이 변경되었습니다. 다시 로그인해주세요.\"}"
+                    );
+                    return;
+                }
+
                 setAuthentiaction(info.getSubject());
+
             }catch (Exception e){
                 log.error(e.getMessage());
                 return;


### PR DESCRIPTION
## 📌 변경 사항
- 매 요청마다 JWT 토큰의 role과 DB에 저장된 사용자 권한을 비교하는 로직을 추가했습니다.
- 권한 불일치 시 401 Unauthorized 응답을 반환하고 재로그인을 유도하도록 처리했습니다.

---

## 🔍 변경 이유
- 기존에는 JWT 토큰의 role만으로 권한을 판단하고 있어,
  DB에서 권한이 변경되어도 즉시 반영되지 않는 문제가 있었습니다.
- 이를 보완하기 위해 매 요청 시 DB 권한을 재검증하도록 개선했습니다.

---

## ⚙️ 주요 로직
- JWT에서 role 추출
- DB에서 UserDetails 조회 후 role 비교
- 불일치 시 401 응답 및 재로그인 유도