### PR TITLE
Refactor/payment, swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'com.mysql:mysql-connector-j'
 
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+
 }
 dependencyManagement {
     imports {

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/SwaggerConfig.java
@@ -1,11 +1,21 @@
 package com.ldif.delivery.global.infrastructure.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -17,18 +27,58 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("Delivery API")
-                        .version("v1.0")
-                        .description("배달 서비스 API"))
-                .addSecurityItem(new SecurityRequirement().addList(jwtSchemeName))
-                .components(
-                        new io.swagger.v3.oas.models.Components()
-                                .addSecuritySchemes(jwtSchemeName,
-                                        new SecurityScheme()
-                                                .name("Authorization")
-                                                .type(SecurityScheme.Type.HTTP)
-                                                .scheme("bearer")
-                                                .bearerFormat("JWT")
+                        .description("Delivery 프로젝트 API 문서")
+                        .version("v1.0.0"))
+
+                // JWT Authorize 버튼 설정
+                .components(new Components()
+                        .addSecuritySchemes(jwtSchemeName,
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                )
+
+                // Filter에서 처리하는 로그인 API를 Swagger에 수동 등록
+                .path("/api/v1/auth/login",
+                        new PathItem().post(new Operation()
+                                .tags(List.of("auth-controller-v-1"))
+                                .summary("로그인")
+                                .description("username과 password로 로그인하고 JWT 토큰을 발급받습니다.")
+                                .requestBody(new RequestBody()
+                                        .required(true)
+                                        .content(new Content()
+                                                .addMediaType("application/json",
+                                                        new MediaType().schema(new ObjectSchema()
+                                                                .addProperty("username", new Schema<>().type("string").example("testUser"))
+                                                                .addProperty("password", new Schema<>().type("string").example("password1234"))
+                                                        )
+                                                )
+                                        )
                                 )
+                                .responses(new io.swagger.v3.oas.models.responses.ApiResponses()
+                                        .addApiResponse("200", new ApiResponse()
+                                                .description("로그인 성공")
+                                                .content(new Content()
+                                                        .addMediaType("application/json",
+                                                                new MediaType().schema(new ObjectSchema()
+                                                                        .addProperty("status", new Schema<>().type("integer").example(200))
+                                                                        .addProperty("message", new Schema<>().type("string").example("SUCCESS"))
+                                                                        .addProperty("data", new ObjectSchema()
+                                                                                .addProperty("token", new Schema<>().type("string").example("eyJhbGciOiJIUzI1NiJ9..."))
+                                                                                .addProperty("username", new Schema<>().type("string").example("testUser"))
+                                                                                .addProperty("role", new Schema<>().type("string").example("CUSTOMER"))
+                                                                        )
+                                                                )
+                                                        )
+                                                )
+                                        )
+                                        .addApiResponse("401", new ApiResponse()
+                                                .description("로그인 실패"))
+                                )
+                        )
                 );
     }
 }

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.ldif.delivery.global.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Delivery API")
+                        .version("v1.0")
+                        .description("배달 서비스 API"))
+                .addSecurityItem(new SecurityRequirement().addList(jwtSchemeName))
+                .components(
+                        new io.swagger.v3.oas.models.Components()
+                                .addSecuritySchemes(jwtSchemeName,
+                                        new SecurityScheme()
+                                                .name("Authorization")
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")
+                                )
+                );
+    }
+}

--- a/src/main/java/com/ldif/delivery/global/infrastructure/config/security/SecurityConfig.java
+++ b/src/main/java/com/ldif/delivery/global/infrastructure/config/security/SecurityConfig.java
@@ -63,6 +63,11 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers(
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/v3/api-docs/**"
+                ).permitAll()
                 .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll()
                 .anyRequest().authenticated()
         );

--- a/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
@@ -6,14 +6,11 @@ import com.ldif.delivery.payment.domain.entity.PaymentStatus;
 import com.ldif.delivery.payment.domain.repository.PaymentRepository;
 import com.ldif.delivery.payment.presentation.dto.PaymentResponse;
 import com.ldif.delivery.payment.presentation.dto.PaymentStatusResponse;
-import com.ldif.delivery.user.domain.entity.UserEntity;
-import com.ldif.delivery.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,13 +24,9 @@ import java.util.UUID;
 public class PaymentServiceV1 {
 
     private final PaymentRepository paymentRepository;
-    private final UserRepository userRepository;
 
-    // 결제 목록 조회
     @Transactional(readOnly = true)
     public Page<PaymentResponse> getPayments(String status, int page, int size, String sort, UserDetailsImpl loginUser) {
-
-        validateUserRole(loginUser);
 
         Sort.Direction direction = sort.equalsIgnoreCase("ASC")
                 ? Sort.Direction.ASC
@@ -56,12 +49,8 @@ public class PaymentServiceV1 {
         return payments.map(PaymentResponse::new);
     }
 
-    // 결제 상세 조회
     @Transactional(readOnly = true)
     public PaymentResponse getPayment(UUID paymentId, UserDetailsImpl loginUser) {
-
-        validateUserRole(loginUser);
-
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
 
@@ -72,12 +61,8 @@ public class PaymentServiceV1 {
         return new PaymentResponse(payment);
     }
 
-    // 결제 상태 조회
     @Transactional(readOnly = true)
     public PaymentStatusResponse getPaymentStatus(UUID paymentId, UserDetailsImpl loginUser) {
-
-        validateUserRole(loginUser);
-
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
 
@@ -88,12 +73,8 @@ public class PaymentServiceV1 {
         return new PaymentStatusResponse(payment);
     }
 
-    // 결제 취소
     @Transactional
     public void cancelPayment(UUID paymentId, UserDetailsImpl loginUser) {
-
-        validateUserRole(loginUser);
-
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
 
@@ -111,22 +92,5 @@ public class PaymentServiceV1 {
         }
 
         payment.cancel();
-    }
-
-    private void validateUserRole(UserDetailsImpl loginUser) {
-
-        if (loginUser == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
-
-        UserEntity user = userRepository.findByUsername(loginUser.getUsername())
-                .orElseThrow(() -> new AccessDeniedException("유저를 찾을 수 없습니다."));
-
-        String dbRole = user.getRole().getAuthority();
-        String tokenRole = loginUser.getAuthorities().iterator().next().getAuthority();
-
-        if (!dbRole.equals(tokenRole)) {
-            throw new AccessDeniedException("권한 정보가 일치하지 않습니다.");
-        }
     }
 }

--- a/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
@@ -2,6 +2,7 @@ package com.ldif.delivery.payment.application.service;
 
 import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
 import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import com.ldif.delivery.payment.domain.entity.PaymentStatus;
 import com.ldif.delivery.payment.domain.repository.PaymentRepository;
 import com.ldif.delivery.payment.presentation.dto.PaymentResponse;
 import com.ldif.delivery.payment.presentation.dto.PaymentStatusResponse;
@@ -48,7 +49,8 @@ public class PaymentServiceV1 {
         if (status == null || status.isBlank()) {
             payments = paymentRepository.findAllByDeletedAtIsNull(pageable);
         } else {
-            payments = paymentRepository.findByStatusAndDeletedAtIsNull(status, pageable);
+            PaymentStatus paymentStatus = PaymentStatus.valueOf(status.toUpperCase());
+            payments = paymentRepository.findByStatusAndDeletedAtIsNull(paymentStatus, pageable);
         }
 
         return payments.map(PaymentResponse::new);
@@ -99,11 +101,11 @@ public class PaymentServiceV1 {
             throw new IllegalStateException("삭제된 결제입니다.");
         }
 
-        if ("CANCELLED".equals(payment.getStatus())) {
+        if (payment.isCancelled()) {
             throw new IllegalStateException("이미 취소된 결제입니다.");
         }
 
-        if ("COMPLETED".equals(payment.getStatus())
+        if (payment.isCompleted()
                 && payment.getCreatedAt().plusMinutes(5).isBefore(LocalDateTime.now())) {
             throw new IllegalStateException("결제 후 5분이 지나 취소할 수 없습니다.");
         }

--- a/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
@@ -6,10 +6,15 @@ import com.ldif.delivery.payment.domain.repository.PaymentRepository;
 import com.ldif.delivery.payment.presentation.dto.PaymentResponse;
 import com.ldif.delivery.payment.presentation.dto.PaymentStatusResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,11 +26,25 @@ public class PaymentServiceV1 {
 
     // 결제 목록 조회
     @Transactional(readOnly = true)
-    public List<PaymentResponse> getPayments() {
-        return paymentRepository.findAll().stream()
-                .filter(payment -> payment.getDeletedAt() == null)
-                .map(PaymentResponse::new)
-                .toList();
+    public Page<PaymentResponse> getPayments(String status, int page, int size, String sort) {
+        Sort.Direction direction = sort.equalsIgnoreCase("ASC")
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        List<Integer> allowedSize = Arrays.asList(10, 30, 50);
+        int setSize = allowedSize.contains(size) ? size : 10;
+
+        Pageable pageable = PageRequest.of(page, setSize, Sort.by(direction, "createdAt"));
+
+        Page<PaymentEntity> payments;
+
+        if (status == null || status.isBlank()) {
+            payments = paymentRepository.findAllByDeletedAtIsNull(pageable);
+        } else {
+            payments = paymentRepository.findByStatusAndDeletedAtIsNull(status, pageable);
+        }
+
+        return payments.map(PaymentResponse::new);
     }
 
     // 결제 상세 조회

--- a/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/ldif/delivery/payment/application/service/PaymentServiceV1.java
@@ -5,11 +5,14 @@ import com.ldif.delivery.payment.domain.entity.PaymentEntity;
 import com.ldif.delivery.payment.domain.repository.PaymentRepository;
 import com.ldif.delivery.payment.presentation.dto.PaymentResponse;
 import com.ldif.delivery.payment.presentation.dto.PaymentStatusResponse;
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,10 +26,14 @@ import java.util.UUID;
 public class PaymentServiceV1 {
 
     private final PaymentRepository paymentRepository;
+    private final UserRepository userRepository;
 
     // 결제 목록 조회
     @Transactional(readOnly = true)
-    public Page<PaymentResponse> getPayments(String status, int page, int size, String sort) {
+    public Page<PaymentResponse> getPayments(String status, int page, int size, String sort, UserDetailsImpl loginUser) {
+
+        validateUserRole(loginUser);
+
         Sort.Direction direction = sort.equalsIgnoreCase("ASC")
                 ? Sort.Direction.ASC
                 : Sort.Direction.DESC;
@@ -50,6 +57,9 @@ public class PaymentServiceV1 {
     // 결제 상세 조회
     @Transactional(readOnly = true)
     public PaymentResponse getPayment(UUID paymentId, UserDetailsImpl loginUser) {
+
+        validateUserRole(loginUser);
+
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
 
@@ -63,6 +73,9 @@ public class PaymentServiceV1 {
     // 결제 상태 조회
     @Transactional(readOnly = true)
     public PaymentStatusResponse getPaymentStatus(UUID paymentId, UserDetailsImpl loginUser) {
+
+        validateUserRole(loginUser);
+
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
 
@@ -76,6 +89,9 @@ public class PaymentServiceV1 {
     // 결제 취소
     @Transactional
     public void cancelPayment(UUID paymentId, UserDetailsImpl loginUser) {
+
+        validateUserRole(loginUser);
+
         PaymentEntity payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
 
@@ -93,5 +109,22 @@ public class PaymentServiceV1 {
         }
 
         payment.cancel();
+    }
+
+    private void validateUserRole(UserDetailsImpl loginUser) {
+
+        if (loginUser == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        UserEntity user = userRepository.findByUsername(loginUser.getUsername())
+                .orElseThrow(() -> new AccessDeniedException("유저를 찾을 수 없습니다."));
+
+        String dbRole = user.getRole().getAuthority();
+        String tokenRole = loginUser.getAuthorities().iterator().next().getAuthority();
+
+        if (!dbRole.equals(tokenRole)) {
+            throw new AccessDeniedException("권한 정보가 일치하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/ldif/delivery/payment/domain/entity/PaymentEntity.java
+++ b/src/main/java/com/ldif/delivery/payment/domain/entity/PaymentEntity.java
@@ -24,35 +24,61 @@ public class PaymentEntity extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false, unique = true)
     private OrderEntity order;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "payment_method", length = 20, nullable = false)
-    private String paymentMethod = "CARD";
+    private PaymentMethod paymentMethod = PaymentMethod.CARD;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
-    private String status = "PENDING";
+    private PaymentStatus status = PaymentStatus.PENDING;
 
     @Column(name = "amount", nullable = false)
     private Integer amount;
 
     public PaymentEntity(OrderEntity order, Integer amount) {
+        if (order == null) {
+            throw new IllegalArgumentException("주문 정보는 필수입니다.");
+        }
+
+        if (amount == null || amount < 0) {
+            throw new IllegalArgumentException("결제 금액은 0 이상이어야 합니다.");
+        }
+
         this.order = order;
         this.amount = amount;
-        this.paymentMethod = "CARD";
-        this.status = "PENDING";
+        this.paymentMethod = PaymentMethod.CARD;
+        this.status = PaymentStatus.PENDING;
     }
 
     public void complete() {
-        this.status = "COMPLETED";
+        if (this.status == PaymentStatus.CANCELLED) {
+            throw new IllegalStateException("취소된 결제는 완료 처리할 수 없습니다.");
+        }
+
+        if (this.status == PaymentStatus.COMPLETED) {
+            throw new IllegalStateException("이미 완료된 결제입니다.");
+        }
+
+        this.status = PaymentStatus.COMPLETED;
     }
 
     public void cancel() {
-        this.status = "CANCELLED";
+        if (this.status == PaymentStatus.CANCELLED) {
+            throw new IllegalStateException("이미 취소된 결제입니다.");
+        }
+
+        this.status = PaymentStatus.CANCELLED;
     }
 
     public boolean isCompleted() {
-        return "COMPLETED".equals(this.status);
+        return this.status == PaymentStatus.COMPLETED;
+    }
+
+    public boolean isCancelled() {
+        return this.status == PaymentStatus.CANCELLED;
     }
 
     public UUID getOrderId() {
-        return order.getOrderId();
+        return this.order.getOrderId();
     }
 }

--- a/src/main/java/com/ldif/delivery/payment/domain/entity/PaymentMethod.java
+++ b/src/main/java/com/ldif/delivery/payment/domain/entity/PaymentMethod.java
@@ -1,0 +1,5 @@
+package com.ldif.delivery.payment.domain.entity;
+
+public enum PaymentMethod {
+    CARD
+}

--- a/src/main/java/com/ldif/delivery/payment/domain/entity/PaymentStatus.java
+++ b/src/main/java/com/ldif/delivery/payment/domain/entity/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.ldif.delivery.payment.domain.entity;
+
+public enum PaymentStatus {
+    PENDING,
+    COMPLETED,
+    CANCELLED
+}

--- a/src/main/java/com/ldif/delivery/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/ldif/delivery/payment/domain/repository/PaymentRepository.java
@@ -1,6 +1,7 @@
 package com.ldif.delivery.payment.domain.repository;
 
 import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import com.ldif.delivery.payment.domain.entity.PaymentStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,6 @@ public interface PaymentRepository extends JpaRepository<PaymentEntity, UUID> {
 
     Page<PaymentEntity> findAllByDeletedAtIsNull(Pageable pageable);
 
-    Page<PaymentEntity> findByStatusAndDeletedAtIsNull(String status, Pageable pageable);
+    Page<PaymentEntity> findByStatusAndDeletedAtIsNull(PaymentStatus status, Pageable pageable);
 
 }

--- a/src/main/java/com/ldif/delivery/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/ldif/delivery/payment/domain/repository/PaymentRepository.java
@@ -1,8 +1,15 @@
 package com.ldif.delivery.payment.domain.repository;
 
 import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface PaymentRepository extends JpaRepository<PaymentEntity, UUID> {
+
+    Page<PaymentEntity> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Page<PaymentEntity> findByStatusAndDeletedAtIsNull(String status, Pageable pageable);
+
 }

--- a/src/main/java/com/ldif/delivery/payment/presentation/controller/PaymentControllerV1.java
+++ b/src/main/java/com/ldif/delivery/payment/presentation/controller/PaymentControllerV1.java
@@ -7,6 +7,7 @@ import com.ldif.delivery.payment.presentation.dto.PaymentResponse;
 import com.ldif.delivery.payment.presentation.dto.PaymentStatusResponse;
 import com.ldif.delivery.user.domain.entity.UserRoleEnum;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
@@ -29,8 +30,13 @@ public class PaymentControllerV1 {
             UserRoleEnum.Authority.MASTER,
             UserRoleEnum.Authority.MANAGER
     })
-    public ResponseEntity<CommonResponse<List<PaymentResponse>>> getPayments() {
-        List<PaymentResponse> payments = paymentServiceV1.getPayments();
+    public ResponseEntity<CommonResponse<Page<PaymentResponse>>> getPayments(
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DESC") String sort
+    ) {
+        Page<PaymentResponse> payments = paymentServiceV1.getPayments(status, page, size, sort);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", payments));

--- a/src/main/java/com/ldif/delivery/payment/presentation/controller/PaymentControllerV1.java
+++ b/src/main/java/com/ldif/delivery/payment/presentation/controller/PaymentControllerV1.java
@@ -14,7 +14,6 @@ import org.springframework.security.access.annotation.Secured;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -34,9 +33,10 @@ public class PaymentControllerV1 {
             @RequestParam(required = false) String status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "DESC") String sort
+            @RequestParam(defaultValue = "DESC") String sort,
+            @AuthenticationPrincipal UserDetailsImpl loginUser
     ) {
-        Page<PaymentResponse> payments = paymentServiceV1.getPayments(status, page, size, sort);
+        Page<PaymentResponse> payments = paymentServiceV1.getPayments(status, page, size, sort, loginUser);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.success(HttpStatus.OK.value(), "SUCCESS", payments));

--- a/src/main/java/com/ldif/delivery/payment/presentation/dto/PaymentResponse.java
+++ b/src/main/java/com/ldif/delivery/payment/presentation/dto/PaymentResponse.java
@@ -1,6 +1,8 @@
 package com.ldif.delivery.payment.presentation.dto;
 
 import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import com.ldif.delivery.payment.domain.entity.PaymentMethod;
+import com.ldif.delivery.payment.domain.entity.PaymentStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -11,8 +13,8 @@ public class PaymentResponse {
 
     private final UUID paymentId;
     private final UUID orderId;
-    private final String paymentMethod;
-    private final String status;
+    private final PaymentMethod paymentMethod;
+    private final PaymentStatus status;
     private final Integer amount;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;

--- a/src/main/java/com/ldif/delivery/payment/presentation/dto/PaymentStatusResponse.java
+++ b/src/main/java/com/ldif/delivery/payment/presentation/dto/PaymentStatusResponse.java
@@ -1,14 +1,16 @@
 package com.ldif.delivery.payment.presentation.dto;
 
 import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import com.ldif.delivery.payment.domain.entity.PaymentStatus;
 import lombok.Getter;
+
 import java.util.UUID;
 
 @Getter
 public class PaymentStatusResponse {
 
     private final UUID paymentId;
-    private final String status;
+    private final PaymentStatus status;
 
     public PaymentStatusResponse(PaymentEntity payment) {
         this.paymentId = payment.getPaymentId();

--- a/src/test/java/com/ldif/delivery/payment/application/service/PaymentServiceV1Test.java
+++ b/src/test/java/com/ldif/delivery/payment/application/service/PaymentServiceV1Test.java
@@ -1,0 +1,196 @@
+package com.ldif.delivery.payment.application.service;
+
+import com.ldif.delivery.global.infrastructure.config.security.UserDetailsImpl;
+import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import com.ldif.delivery.payment.domain.repository.PaymentRepository;
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import com.ldif.delivery.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceV1Test {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PaymentServiceV1 paymentService;
+
+    private UserDetailsImpl mockLoginUser() {
+        UserDetailsImpl loginUser = mock(UserDetailsImpl.class);
+
+        given(loginUser.getUsername()).willReturn("testUser");
+
+        List<GrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority(UserRoleEnum.Authority.MASTER)
+        );
+
+        doReturn(authorities).when(loginUser).getAuthorities();
+
+        UserEntity user = mock(UserEntity.class);
+        given(user.getRole()).willReturn(UserRoleEnum.MASTER);
+        given(userRepository.findByUsername("testUser"))
+                .willReturn(Optional.of(user));
+
+        return loginUser;
+    }
+
+    @Test
+    @DisplayName("결제 조회 실패 - 결제를 찾을 수 없음")
+    void getPayment_fails_whenPaymentNotFound() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.getPayment(paymentId, loginUser))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("결제 상태 조회 실패 - 결제를 찾을 수 없음")
+    void getPaymentStatus_fails_whenPaymentNotFound() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.getPaymentStatus(paymentId, loginUser))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("결제 취소 실패 - 결제를 찾을 수 없음")
+    void cancelPayment_fails_whenPaymentNotFound() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.cancelPayment(paymentId, loginUser))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("결제 취소 성공 - 결제 대기 상태")
+    void cancelPayment_succeeds_whenPaymentIsPending() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+        PaymentEntity payment = mock(PaymentEntity.class);
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.of(payment));
+
+        given(payment.getDeletedAt()).willReturn(null);
+        given(payment.isCancelled()).willReturn(false);
+        given(payment.isCompleted()).willReturn(false);
+
+        // when
+        paymentService.cancelPayment(paymentId, loginUser);
+
+        // then
+        verify(payment).cancel();
+    }
+
+    @Test
+    @DisplayName("결제 취소 성공 - 결제 완료 후 5분 이내")
+    void cancelPayment_succeeds_whenCompletedWithinFiveMinutes() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+        PaymentEntity payment = mock(PaymentEntity.class);
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.of(payment));
+
+        given(payment.getDeletedAt()).willReturn(null);
+        given(payment.isCancelled()).willReturn(false);
+        given(payment.isCompleted()).willReturn(true);
+        given(payment.getCreatedAt()).willReturn(LocalDateTime.now().minusMinutes(3));
+
+        // when
+        paymentService.cancelPayment(paymentId, loginUser);
+
+        // then
+        verify(payment).cancel();
+    }
+
+    @Test
+    @DisplayName("결제 취소 실패 - 결제 완료 후 5분 초과")
+    void cancelPayment_fails_whenCompletedAfterFiveMinutes() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+        PaymentEntity payment = mock(PaymentEntity.class);
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.of(payment));
+
+        given(payment.getDeletedAt()).willReturn(null);
+        given(payment.isCancelled()).willReturn(false);
+        given(payment.isCompleted()).willReturn(true);
+        given(payment.getCreatedAt()).willReturn(LocalDateTime.now().minusMinutes(6));
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.cancelPayment(paymentId, loginUser))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("결제 후 5분이 지나 취소할 수 없습니다.");
+
+        verify(payment, never()).cancel();
+    }
+
+    @Test
+    @DisplayName("결제 취소 실패 - 이미 취소된 결제")
+    void cancelPayment_fails_whenAlreadyCancelled() {
+        // given
+        UUID paymentId = UUID.randomUUID();
+        UserDetailsImpl loginUser = mockLoginUser();
+        PaymentEntity payment = mock(PaymentEntity.class);
+
+        given(paymentRepository.findById(paymentId))
+                .willReturn(Optional.of(payment));
+
+        given(payment.getDeletedAt()).willReturn(null);
+        given(payment.isCancelled()).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> paymentService.cancelPayment(paymentId, loginUser))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 취소된 결제입니다.");
+
+        verify(payment, never()).cancel();
+    }
+}

--- a/src/test/java/com/ldif/delivery/payment/application/service/PaymentServiceV1Test.java
+++ b/src/test/java/com/ldif/delivery/payment/application/service/PaymentServiceV1Test.java
@@ -30,29 +30,11 @@ class PaymentServiceV1Test {
     @Mock
     private PaymentRepository paymentRepository;
 
-    @Mock
-    private UserRepository userRepository;
-
     @InjectMocks
     private PaymentServiceV1 paymentService;
 
     private UserDetailsImpl mockLoginUser() {
-        UserDetailsImpl loginUser = mock(UserDetailsImpl.class);
-
-        given(loginUser.getUsername()).willReturn("testUser");
-
-        List<GrantedAuthority> authorities = List.of(
-                new SimpleGrantedAuthority(UserRoleEnum.Authority.MASTER)
-        );
-
-        doReturn(authorities).when(loginUser).getAuthorities();
-
-        UserEntity user = mock(UserEntity.class);
-        given(user.getRole()).willReturn(UserRoleEnum.MASTER);
-        given(userRepository.findByUsername("testUser"))
-                .willReturn(Optional.of(user));
-
-        return loginUser;
+        return mock(UserDetailsImpl.class);
     }
 
     @Test

--- a/src/test/java/com/ldif/delivery/payment/domain/repository/PaymentRepositoryTest.java
+++ b/src/test/java/com/ldif/delivery/payment/domain/repository/PaymentRepositoryTest.java
@@ -1,0 +1,164 @@
+package com.ldif.delivery.payment.domain.repository;
+
+import com.ldif.delivery.area.domain.entity.AreaEntity;
+import com.ldif.delivery.area.persentation.dto.AreaRequest;
+import com.ldif.delivery.category.domain.entity.CategoryEntity;
+import com.ldif.delivery.order.domain.entity.OrderEntity;
+import com.ldif.delivery.order.domain.entity.OrderType;
+import com.ldif.delivery.payment.domain.entity.PaymentEntity;
+import com.ldif.delivery.payment.domain.entity.PaymentStatus;
+import com.ldif.delivery.store.domain.entity.StoreEntity;
+import com.ldif.delivery.user.domain.entity.UserEntity;
+import com.ldif.delivery.user.domain.entity.UserRoleEnum;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DataJpaTest
+@TestPropertySource(properties = {"spring.sql.init.mode=never"})
+@Import(PaymentRepositoryTest.QuerydslTestConfig.class)
+class PaymentRepositoryTest {
+
+    @TestConfiguration
+    static class QuerydslTestConfig {
+
+        @PersistenceContext
+        private EntityManager entityManager;
+
+        @Bean
+        JPAQueryFactory jpaQueryFactory() {
+            return new JPAQueryFactory(entityManager);
+        }
+    }
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void findAllByDeletedAtIsNull_returnsOnlyNotDeletedPayments() {
+        OrderEntity order1 = createOrder();
+        OrderEntity order2 = createOrder();
+
+        PaymentEntity payment = new PaymentEntity(order1, 10000);
+
+        PaymentEntity deletedPayment = new PaymentEntity(order2, 20000);
+        deletedPayment.softDelete("testUser");
+
+        em.persist(payment);
+        em.persist(deletedPayment);
+        em.flush();
+        em.clear();
+
+        Page<PaymentEntity> result =
+                paymentRepository.findAllByDeletedAtIsNull(PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getAmount()).isEqualTo(10000);
+    }
+
+    @Test
+    void findByStatusAndDeletedAtIsNull_returnsMatchingStatusOnly() {
+        OrderEntity order1 = createOrder();
+        OrderEntity order2 = createOrder();
+
+        PaymentEntity pendingPayment = new PaymentEntity(order1, 10000);
+
+        PaymentEntity cancelledPayment = new PaymentEntity(order2, 20000);
+        cancelledPayment.cancel();
+
+        em.persist(pendingPayment);
+        em.persist(cancelledPayment);
+        em.flush();
+        em.clear();
+
+        Page<PaymentEntity> result =
+                paymentRepository.findByStatusAndDeletedAtIsNull(
+                        PaymentStatus.PENDING,
+                        PageRequest.of(0, 10)
+                );
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getStatus())
+                .isEqualTo(PaymentStatus.PENDING);
+    }
+
+    private OrderEntity createOrder() {
+        UserEntity customer = createUser("user" + UUID.randomUUID().toString().substring(0, 4), UserRoleEnum.CUSTOMER);
+        UserEntity owner = createUser("own" + UUID.randomUUID().toString().substring(0, 5), UserRoleEnum.OWNER);
+
+        CategoryEntity category = createCategory();
+        AreaEntity area = createArea();
+
+        em.persist(customer);
+        em.persist(owner);
+        em.persist(category);
+        em.persist(area);
+
+        StoreEntity store = new StoreEntity(
+                owner,
+                category,
+                area,
+                "테스트 가게",
+                "서울시 종로구",
+                "010-1234-5678"
+        );
+
+        em.persist(store);
+
+        OrderEntity order = OrderEntity.create(
+                customer,
+                store,
+                UUID.randomUUID(),
+                OrderType.ONLINE,
+                "요청사항 없음",
+                List.of(),
+                10000
+        );
+
+        return em.persist(order);
+    }
+
+    private UserEntity createUser(String username, UserRoleEnum role) {
+        return new UserEntity(
+                username,
+                username,
+                username + "@test.com",
+                "password",
+                role
+        );
+    }
+
+    private CategoryEntity createCategory() {
+        return new CategoryEntity("한식" + UUID.randomUUID());
+    }
+
+    private AreaEntity createArea() {
+        AreaRequest request = mock(AreaRequest.class);
+
+        when(request.getName()).thenReturn("서울" + UUID.randomUUID());
+        when(request.getCity()).thenReturn("서울시");
+        when(request.getDistrict()).thenReturn("종로구");
+
+        return new AreaEntity(request);
+    }
+}


### PR DESCRIPTION
- payment 페이징 처리
- payment api에 db 권한 재검증 로직 추가
- payment 상태 및 결제수단 enum 적용 및 도메인 검증 로직 추가
- payment repository, service 테스트 코드 작성
- Swagger 설정 http://localhost:8080/swagger-ui/index.html#/

- PaymentService에서 JWT 권한 검증 제거 및 테스트 코드 정리