### PR TITLE
Feature/주문 동시성 제어 및 멱등성 보장을 위한 로직 추가

### DIFF
--- a/src/main/java/com/ldif/delivery/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/ldif/delivery/order/application/service/OrderServiceV1.java
@@ -205,17 +205,28 @@ public class OrderServiceV1 {
     public OrderResponse updateOrder(UUID orderId, OrderUpdateRequest req,
                                      String requesterId, String requesterRole) {
 
-        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
-                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        OrderEntity order = findActiveByIdWithLock(orderId);
 
         if ("MASTER".equals(requesterRole)) {
             order.updateRequestByMaster(req.request());
-        } else {
-            // CUSTOMER: 본인 주문인지 확인
-            validateOwnership(order, requesterId);
-            order.updateRequest(req.request()); // PENDING 아니면 내부에서 예외
+            return  OrderResponse.from(order);
         }
 
+        // CUSTOMER: 본인 주문인지 확인
+        validateOwnership(order, requesterId);
+
+        // 멱등성 보장: 이미 같은 요청사항이면 그대로 반환
+        if (req.request() != null &&
+                req.request().equals(order.getRequest())) {
+            return OrderResponse.from(order);
+        }
+
+        // PENDING이 아닌 상태면 예외 대신 현재 상태 반환
+        if (order.getStatus() != OrderStatus.PENDING) {
+            return OrderResponse.from(order);
+        }
+
+        order.updateRequest(req.request());
         return OrderResponse.from(order);
     }
 
@@ -226,11 +237,15 @@ public class OrderServiceV1 {
     public OrderResponse changeStatus(UUID orderId, OrderStatusRequest req,
                                       String requesterId, String requesterRole) {
 
-        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
-                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        OrderEntity order = findActiveByIdWithLock(orderId);
 
         if ("OWNER".equals(requesterRole)) {
             validateStoreOwner(order.getStore().getStoreId(), requesterId);
+        }
+
+        // 멱등성 보장: 이미 같은 상태이면 그대로 반환
+        if (order.getStatus() == req.status()) {
+            return OrderResponse.from(order);
         }
 
         order.changeStatus(req.status());
@@ -243,8 +258,7 @@ public class OrderServiceV1 {
     @Transactional
     public OrderResponse cancelOrder(UUID orderId, String requesterId, String requesterRole) {
 
-        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
-                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        OrderEntity order = findActiveByIdWithLock(orderId);
 
         // 취소 멱등성 보장: 이미 취소된 주문이면 예외 대신 현재 상태 그대로 반환
         if (order.getStatus() == OrderStatus.CANCELED) {
@@ -275,11 +289,16 @@ public class OrderServiceV1 {
     @Transactional
     public void  deleteOrder(UUID orderId, String masterUsername) {
 
-        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
-                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        OrderEntity order = findActiveByIdWithLock(orderId);
         order.softDelete(masterUsername);
     }
 
+
+    // 주문 접근 가능자 확인
+    private OrderEntity findActiveByIdWithLock(UUID orderId) {
+        return orderRepository.findActiveByIdWithLock(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+    }
 
     // 주문 접근 가능자 확인
     private void validateOwnership(OrderEntity order, String requesterId) {

--- a/src/main/java/com/ldif/delivery/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/ldif/delivery/order/application/service/OrderServiceV1.java
@@ -221,12 +221,9 @@ public class OrderServiceV1 {
             return OrderResponse.from(order);
         }
 
-        // PENDING이 아닌 상태면 예외 대신 현재 상태 반환
-        if (order.getStatus() != OrderStatus.PENDING) {
-            return OrderResponse.from(order);
-        }
-
+        // PENDING이 아닌 상태면 예외 (내부에서 검증)
         order.updateRequest(req.request());
+
         return OrderResponse.from(order);
     }
 
@@ -248,7 +245,9 @@ public class OrderServiceV1 {
             return OrderResponse.from(order);
         }
 
+        // 잘못된 상태 변화이면 예외 (내부에서 검증)
         order.changeStatus(req.status());
+
         return OrderResponse.from(order);
     }
 

--- a/src/main/java/com/ldif/delivery/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/ldif/delivery/order/application/service/OrderServiceV1.java
@@ -49,7 +49,16 @@ public class OrderServiceV1 {
     @Transactional
     public OrderResponse createOrder(OrderCreateRequest req, String customerId) {
 
-        //1. 주문자 조회
+        // 중복 주문 방지: 같은 고객이 같은 가게에 PENDING 주문이 이미 있으면 차단
+        boolean hasPendingOrder = orderRepository
+                .existsByCustomer_UsernameAndStore_StoreIdAndStatus(
+                        customerId, req.storeId(), OrderStatus.PENDING);
+
+        if (hasPendingOrder) {
+            throw new OrderBusinessException("이미 처리 중인 주문이 있습니다.");
+        }
+
+        // 1. 주문자 조회
         UserEntity customer = userRepository.findById(customerId)
                 .orElseThrow(() -> new IllegalArgumentException(
                         "존재하지 않는 사용자입니다. customerId=" + customerId));
@@ -183,7 +192,8 @@ public class OrderServiceV1 {
     // ───────────────────────────────────────────────────────────
     public OrderResponse getOrder(UUID orderId, String requesterId, String requesterRole) {
 
-        OrderEntity order = findActiveOrder(orderId);
+        OrderEntity order = orderRepository.findActiveById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
         validateReadAccess(order, requesterId, requesterRole);
         return OrderResponse.from(order);
     }
@@ -195,7 +205,8 @@ public class OrderServiceV1 {
     public OrderResponse updateOrder(UUID orderId, OrderUpdateRequest req,
                                      String requesterId, String requesterRole) {
 
-        OrderEntity order = findActiveOrder(orderId);
+        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
 
         if ("MASTER".equals(requesterRole)) {
             order.updateRequestByMaster(req.request());
@@ -215,7 +226,8 @@ public class OrderServiceV1 {
     public OrderResponse changeStatus(UUID orderId, OrderStatusRequest req,
                                       String requesterId, String requesterRole) {
 
-        OrderEntity order = findActiveOrder(orderId);
+        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
 
         if ("OWNER".equals(requesterRole)) {
             validateStoreOwner(order.getStore().getStoreId(), requesterId);
@@ -230,7 +242,14 @@ public class OrderServiceV1 {
     // ───────────────────────────────────────────────────────────
     @Transactional
     public OrderResponse cancelOrder(UUID orderId, String requesterId, String requesterRole) {
-        OrderEntity order = findActiveOrder(orderId);
+
+        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+        // 취소 멱등성 보장: 이미 취소된 주문이면 예외 대신 현재 상태 그대로 반환
+        if (order.getStatus() == OrderStatus.CANCELED) {
+            return OrderResponse.from(order);
+        }
 
         if ("MASTER".equals(requesterRole)) {
             order.changeStatus(OrderStatus.CANCELED);
@@ -256,16 +275,11 @@ public class OrderServiceV1 {
     @Transactional
     public void  deleteOrder(UUID orderId, String masterUsername) {
 
-        OrderEntity order = findActiveOrder(orderId);
+        OrderEntity order = orderRepository.findActiveByIdWithLock(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
         order.softDelete(masterUsername);
     }
 
-
-    // 주문 존재 여부 확인
-    private OrderEntity findActiveOrder(UUID orderId) {
-        return orderRepository.findActiveById(orderId)
-                .orElseThrow(() -> new OrderNotFoundException(orderId));
-    }
 
     // 주문 접근 가능자 확인
     private void validateOwnership(OrderEntity order, String requesterId) {

--- a/src/main/java/com/ldif/delivery/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/ldif/delivery/order/domain/repository/OrderRepository.java
@@ -1,8 +1,11 @@
 package com.ldif.delivery.order.domain.repository;
 
 import com.ldif.delivery.order.domain.entity.OrderEntity;
+import com.ldif.delivery.order.domain.entity.OrderStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,7 +14,15 @@ import java.util.UUID;
 
 public interface OrderRepository extends JpaRepository<OrderEntity, UUID>, OrderRepositoryCustom {
 
-    // 소프트 삭제된 건 제외한 단건 조회
+    // 소프트 삭제된 건 제외한 단건 조회 (getOrder)
     @Query("SELECT o FROM OrderEntity o WHERE o.orderId = :orderId AND o.deletedAt IS NULL")
     Optional<OrderEntity> findActiveById(@Param("orderId") UUID orderId);
+
+    // 비관적 락 (changeStatus, cancelOrder, updateOrder, deleteOrder)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM OrderEntity o WHERE o.orderId = :orderId AND o.deletedAt IS NULL")
+    Optional<OrderEntity> findActiveByIdWithLock(@Param("orderId") UUID orderId);
+
+    // 중복 주문 방지 (createOrder)
+    boolean existsByCustomer_UsernameAndStore_StoreIdAndStatus(String username, UUID storeId, OrderStatus status);
 }


### PR DESCRIPTION
## 📌 변경 사항

- 주문 조회/수정 시 동시성 제어를 위해 비관적 락 적용
- 주문 생성 시 중복 주문 방지 로직 추가
- 주문 수정, 취소 및 상태 변경 API에 멱등성 보장 로직 추가

## 🔍 변경 이유

- 동시 요청으로 인한 주문 상태 충돌을 방지하기 위해 비관적 락 적용
- 중복 요청으로 동일 주문이 생성되는 문제를 완화하기 위해 중복 체크 로직 추가
- 수정, 취소, 상태 변경 API 재요청 시 불필요한 변경을 방지하하고 동일 결과를 보장하기 위해 멱등성 처리 적용

## ⚙️ 기대 효과

- 주문 수정/취소 시 데이터 정합성 향상
- 중복 주문 생성 가능성 감소 (1차 방어)
- 수정, 취소, 상태 변경 API의 중복 요청 처리 안정성 향상